### PR TITLE
feat: add and add-local commands for individual mod management

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,40 @@ nexus-dl load-order ~/mods/starfield
 
 Regenerates `load-order.txt` (and `plugins.txt` for Bethesda games) from the cached collection manifest without re-downloading anything.
 
+### Deploy to game directory
+
+```bash
+# Auto-detect game path from Steam
+nexus-dl deploy ~/mods/starfield
+
+# First time with a non-Steam game: specify paths manually
+nexus-dl deploy ~/mods/starfield \
+  --game-dir /mnt/games/SteamLibrary/steamapps/common/Starfield \
+  --prefix ~/.steam/debian-installation/steamapps/compatdata/1234567/pfx
+
+# Copy files instead of symlinking
+nexus-dl deploy ~/mods/starfield --copy
+
+# Preview what would be deployed
+nexus-dl deploy ~/mods/starfield --dry-run
+```
+
+Creates symlinks (or copies) from your staging directory into the game's install directory. For Bethesda games on Proton, it also writes `plugins.txt` and `StarfieldCustom.ini` (or equivalent) to the correct Wine prefix paths.
+
+`--game-dir` and `--prefix` are saved after the first deploy, so subsequent runs only need `nexus-dl deploy ~/mods/starfield`.
+
+Redeploying is safe - it removes previously deployed files before creating new ones, so no orphaned symlinks accumulate.
+
+**SFSE/script extender note:** If the collection includes SFSE, the tool deploys `sfse_loader.exe` to the game root and prints launch instructions. For non-Steam games, set your Steam shortcut TARGET to `sfse_loader.exe`. Do not rename it - SFSE needs the original game executable alongside it.
+
+### Remove deployed mods
+
+```bash
+nexus-dl undeploy ~/mods/starfield
+```
+
+Removes all symlinks/copies that were deployed and restores the game directory to its pre-mod state.
+
 ### View status
 
 ```bash
@@ -142,6 +176,8 @@ Masterlists are cached in `~/.cache/nexus-dl/masterlists/` and refreshed every 2
 
 - **sync** - Fetches the collection from the Nexus API, downloads each mod, extracts archives, parses the collection manifest, and generates load order files.
 - **update** - Re-fetches the collection and downloads any mods that have newer versions. Regenerates load order.
+- **deploy** - Classifies files by type and symlinks (or copies) them to the correct game directory locations. Handles SFSE, Data/ assets, plugins, and Proton config files.
+- **undeploy** - Removes all deployed files using the tracked manifest, restoring the game directory.
 - **load-order** - Regenerates load order from the cached manifest (no API call needed).
 - **status** - Shows what's installed and whether updates are available.
 

--- a/nexus_collection_dl/api.py
+++ b/nexus_collection_dl/api.py
@@ -209,6 +209,14 @@ class NexusAPI:
 
         return data[0].get("URI")
 
+    def get_mod_files(self, game_domain: str, mod_id: int) -> list[dict[str, Any]]:
+        """List all files for a mod."""
+        self._rate_limit_wait()
+        url = f"{REST_BASE_URL}/games/{game_domain}/mods/{mod_id}/files.json"
+        response = self.session.get(url)
+        data = self._handle_response(response)
+        return data.get("files", [])
+
     def get_mod_info(self, game_domain: str, mod_id: int) -> dict[str, Any]:
         """Get mod metadata from REST API."""
         self._rate_limit_wait()

--- a/nexus_collection_dl/cli.py
+++ b/nexus_collection_dl/cli.py
@@ -7,8 +7,20 @@ import click
 from rich.console import Console
 from rich.table import Table
 
+from datetime import datetime, timezone
+
 from .api import NexusAPI, NexusAPIError, NexusPremiumRequired, NexusRateLimited
-from .collection import CollectionParseError, parse_collection_url
+from .collection import CollectionParseError, ModParseError, parse_collection_url, parse_mod_url
+from .deploy import (
+    DeployedFile,
+    classify_files,
+    deploy as deploy_files,
+    get_game_ini_path,
+    get_plugins_txt_dest,
+    undeploy as undeploy_files,
+    write_game_ini,
+    write_plugins_txt,
+)
 from .downloader import DownloadError, Downloader
 from .extractor import ExtractionError, extract_archive, is_archive, move_file
 from .loadorder import LoadOrderGenerator
@@ -21,6 +33,7 @@ from .loot_sort import (
 )
 from .manifest import CollectionManifest, ManifestError, download_and_parse_manifest
 from .state import CollectionState, StateError
+from .steam import find_game_dir, find_proton_prefix
 
 console = Console()
 
@@ -546,6 +559,523 @@ def load_order(ctx: click.Context, mods_dir: Path) -> None:
         )
 
     console.print("[green]Load order regenerated![/green]")
+
+
+@main.command()
+@click.argument("mods_dir", type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--game-dir",
+    type=click.Path(path_type=Path),
+    help="Game install directory (auto-detected from Steam if not specified)",
+)
+@click.option(
+    "--prefix",
+    type=click.Path(path_type=Path),
+    help="Proton/Wine prefix path (auto-detected if not specified)",
+)
+@click.option("--copy", "use_copy", is_flag=True, help="Copy files instead of symlinking")
+@click.option("--dry-run", is_flag=True, help="Show what would be deployed without doing it")
+@click.pass_context
+def deploy(
+    ctx: click.Context,
+    mods_dir: Path,
+    game_dir: Path | None,
+    prefix: Path | None,
+    use_copy: bool,
+    dry_run: bool,
+) -> None:
+    """
+    Deploy mods from staging directory to game directory.
+
+    MODS_DIR: Directory containing previously synced mods
+    """
+    # Load state
+    state = CollectionState(mods_dir)
+    try:
+        state.load()
+    except StateError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        console.print("Run 'sync' first to download a collection.")
+        sys.exit(1)
+
+    game_domain = state.game_domain
+    console.print(f"[bold]Collection:[/bold] {state.collection_name}")
+    console.print(f"[bold]Game:[/bold] {game_domain}")
+
+    # Detect game directory (flag > saved state > auto-detect)
+    if game_dir is None and state.game_dir:
+        game_dir = Path(state.game_dir)
+        console.print(f"[dim]Using saved game directory.[/dim]")
+    if game_dir is None:
+        console.print("[dim]Detecting game directory from Steam...[/dim]")
+        game_dir = find_game_dir(game_domain)
+        if game_dir is None:
+            console.print(
+                "[red]Error:[/red] Could not find game directory. "
+                "Use --game-dir to specify it manually."
+            )
+            sys.exit(1)
+
+    if not game_dir.exists():
+        console.print(f"[red]Error:[/red] Game directory does not exist: {game_dir}")
+        sys.exit(1)
+
+    console.print(f"[bold]Game directory:[/bold] {game_dir}")
+
+    # Detect Proton prefix (flag > saved state > auto-detect)
+    if prefix is None and state.proton_prefix:
+        prefix = Path(state.proton_prefix)
+        console.print(f"[dim]Using saved Proton prefix.[/dim]")
+    if prefix is None:
+        prefix = find_proton_prefix(game_domain)
+    if prefix:
+        console.print(f"[bold]Proton prefix:[/bold] {prefix}")
+
+    # Clean up previous deployment if present
+    if state.deployed_files and not dry_run:
+        console.print(
+            f"\n[dim]Removing previous deployment ({len(state.deployed_files)} files)...[/dim]"
+        )
+        removed = undeploy_files(state.deployed_files)
+        console.print(f"[dim]Removed {removed} previously deployed files.[/dim]")
+        state.deployed_files = []
+        state.deployed_at = None
+
+    # Classify files
+    console.print("\n[dim]Classifying files...[/dim]")
+    plan = classify_files(mods_dir, game_domain)
+
+    console.print(f"  Game root files: {len(plan.game_root_files)}")
+    console.print(f"  Data files: {len(plan.data_files)}")
+    console.print(f"  Skipped: {len(plan.skipped)}")
+
+    if plan.total_files == 0:
+        console.print("[yellow]No files to deploy.[/yellow]")
+        return
+
+    # Deploy
+    method = "copy" if use_copy else "symlink"
+    action = "Would deploy" if dry_run else "Deploying"
+    console.print(f"\n[bold]{action} {plan.total_files} files via {method}...[/bold]")
+
+    result = deploy_files(plan, game_dir, method=method, dry_run=dry_run)
+
+    # Write plugins.txt to AppData
+    if prefix and not dry_run:
+        plugins_src = mods_dir / "plugins.txt"
+        plugins_dest = get_plugins_txt_dest(prefix, game_domain)
+        if plugins_dest and plugins_src.exists():
+            write_plugins_txt(plugins_src, plugins_dest)
+            console.print(f"  [green]Wrote[/green] plugins.txt -> {plugins_dest}")
+
+    # Write game INI
+    if prefix and not dry_run:
+        ini_path = get_game_ini_path(prefix, game_domain)
+        if ini_path:
+            if write_game_ini(ini_path, game_domain):
+                console.print(f"  [green]Wrote[/green] {ini_path.name} -> {ini_path}")
+
+    # Show conflicts
+    if result.conflicts:
+        console.print(f"\n[yellow]Conflicts ({len(result.conflicts)}):[/yellow]")
+        for conflict in result.conflicts[:10]:
+            console.print(f"  [yellow]![/yellow] {conflict}")
+        if len(result.conflicts) > 10:
+            console.print(f"  ... and {len(result.conflicts) - 10} more")
+
+    # Show errors
+    if result.errors:
+        console.print(f"\n[red]Errors ({len(result.errors)}):[/red]")
+        for error in result.errors[:10]:
+            console.print(f"  [red]x[/red] {error}")
+
+    # Summary
+    console.print(
+        f"\n[green]Deployed {len(result.deployed)} files "
+        f"({len(result.conflicts)} conflicts, {len(result.errors)} errors)[/green]"
+    )
+
+    # Save deployment state
+    if not dry_run:
+        state.game_dir = str(game_dir)
+        if prefix:
+            state.proton_prefix = str(prefix)
+        state.deployed_files = [f.to_dict() for f in result.deployed]
+        state.deployed_at = datetime.now(timezone.utc).isoformat()
+        state.save()
+        console.print(f"[dim]Deployment state saved.[/dim]")
+
+    # Post-deploy: SFSE launch instructions
+    has_sfse = any(
+        "sfse_loader" in str(f.dest).lower() for f in result.deployed
+    )
+    if has_sfse:
+        sfse_path = game_dir / "sfse_loader.exe"
+        console.print(f"\n[bold yellow]SFSE detected![/bold yellow]")
+        console.print(
+            "  To launch with mods, set your Steam shortcut TARGET to:"
+        )
+        console.print(f"  [cyan]{sfse_path}[/cyan]")
+        console.print(
+            "  Do NOT rename sfse_loader.exe - SFSE needs the original "
+            "game exe alongside it."
+        )
+
+
+@main.command()
+@click.argument("mods_dir", type=click.Path(exists=True, path_type=Path))
+@click.pass_context
+def undeploy(ctx: click.Context, mods_dir: Path) -> None:
+    """
+    Remove all deployed mod files from game directory.
+
+    MODS_DIR: Directory containing previously synced mods
+    """
+    state = CollectionState(mods_dir)
+    try:
+        state.load()
+    except StateError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        sys.exit(1)
+
+    if not state.deployed_files:
+        console.print("[yellow]No deployment found. Nothing to undeploy.[/yellow]")
+        return
+
+    console.print(f"[bold]Collection:[/bold] {state.collection_name}")
+    console.print(f"[bold]Game directory:[/bold] {state.game_dir}")
+    console.print(f"[bold]Deployed files:[/bold] {len(state.deployed_files)}")
+    console.print(f"[bold]Deployed at:[/bold] {state.deployed_at}")
+
+    console.print("\n[bold]Removing deployed files...[/bold]")
+    removed = undeploy_files(state.deployed_files)
+
+    # Clear deployment state
+    state.deployed_files = []
+    state.deployed_at = None
+    state.game_dir = ""
+    state.save()
+
+    console.print(f"\n[green]Removed {removed} files. Game directory restored.[/green]")
+
+
+def _select_mod_file(
+    files: list[dict], file_id_override: int | None = None
+) -> dict | None:
+    """
+    Select a file from the mod's file list.
+
+    Priority:
+    1. file_id override (exact match)
+    2. MAIN category, highest file_id (most recent)
+    3. Any non-archived file, highest file_id
+    4. None (caller should list files for user to pick)
+    """
+    if not files:
+        return None
+
+    if file_id_override is not None:
+        for f in files:
+            if f.get("file_id") == file_id_override:
+                return f
+        return None
+
+    # Category IDs: 1=MAIN, 2=UPDATE, 3=OPTIONAL, 4=OLD, 5=MISC, 6=ARCHIVED
+    main_files = [f for f in files if f.get("category_id") == 1]
+    if main_files:
+        return max(main_files, key=lambda f: f.get("file_id", 0))
+
+    non_archived = [f for f in files if f.get("category_id") != 6]
+    if non_archived:
+        return max(non_archived, key=lambda f: f.get("file_id", 0))
+
+    return None
+
+
+def _regen_load_order_from_state(mods_dir: Path, state: CollectionState) -> None:
+    """Regenerate load order from cached manifest + current state mods."""
+    if not state.manifest_data:
+        console.print("[dim]No cached manifest - skipping load order regen.[/dim]")
+        return
+
+    manifest = CollectionManifest.from_dict(state.manifest_data)
+
+    # Inject phase 999 for manual mods
+    for mod_id, ms in state.mods.items():
+        if ms.manual:
+            manifest.mod_phases[mod_id] = 999
+
+    mod_requirements: dict[int, list[int]] = {}
+    for mod_id, mod_state in state.mods.items():
+        if mod_state.requirements:
+            mod_requirements[mod_id] = mod_state.requirements
+
+    mods_list = [
+        {
+            "mod_id": mod_id,
+            "mod_name": ms.name,
+            "file_id": ms.file_id,
+            "version": ms.version,
+            "filename": ms.filename,
+            "optional": ms.optional,
+        }
+        for mod_id, ms in state.mods.items()
+    ]
+
+    generator = LoadOrderGenerator(
+        manifest=manifest,
+        mods=mods_list,
+        mod_requirements=mod_requirements,
+        game_domain=state.game_domain,
+    )
+
+    try:
+        written = generator.generate(mods_dir)
+        for path in written:
+            console.print(f"  [green]Wrote[/green] {path.name}")
+    except Exception as e:
+        console.print(f"[yellow]Load order regen failed:[/yellow] {e}")
+        return
+
+    if is_bethesda_game(state.game_domain) and is_loot_available():
+        console.print("[dim]Running LOOT plugin sort...[/dim]")
+        loot_sorted = sort_plugins_with_loot(state.game_domain, mods_dir, None)
+        merged = merge_plugin_orders(manifest.plugins, loot_sorted)
+        used_loot = loot_sorted is not None
+        plugins_path = mods_dir / "plugins.txt"
+        write_loot_plugins_txt(merged, plugins_path, state.game_domain, used_loot)
+        source = "LOOT-sorted" if used_loot else "collection metadata"
+        console.print(f"  [green]Wrote[/green] plugins.txt ({source})")
+
+
+@main.command()
+@click.argument("mod_url")
+@click.argument("mods_dir", type=click.Path(exists=True, path_type=Path))
+@click.option("--file-id", type=int, default=None, help="Specific file ID to download")
+@click.option("--no-load-order", is_flag=True, help="Skip load order regeneration")
+@click.pass_context
+def add(
+    ctx: click.Context,
+    mod_url: str,
+    mods_dir: Path,
+    file_id: int | None,
+    no_load_order: bool,
+) -> None:
+    """
+    Add a single mod by URL.
+
+    MOD_URL: Nexus Mods mod page URL (e.g. https://www.nexusmods.com/starfield/mods/123)
+    MODS_DIR: Directory containing a previously synced collection
+    """
+    api_key = ctx.obj.get("api_key")
+
+    # Parse mod URL
+    try:
+        mod_info = parse_mod_url(mod_url)
+    except ModParseError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        sys.exit(1)
+
+    console.print(
+        f"[bold]Mod:[/bold] {mod_info.game_domain} / mod {mod_info.mod_id}"
+    )
+
+    # Load existing state
+    state = CollectionState(mods_dir)
+    try:
+        state.load()
+    except StateError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        console.print("Run 'sync' first to download a collection.")
+        sys.exit(1)
+
+    # Validate game domain matches
+    if state.game_domain and state.game_domain.lower() != mod_info.game_domain.lower():
+        console.print(
+            f"[red]Error:[/red] Mod is for '{mod_info.game_domain}' but collection "
+            f"is for '{state.game_domain}'"
+        )
+        sys.exit(1)
+
+    # Initialize API and validate premium
+    try:
+        api = NexusAPI(api_key)
+        user_info = api.validate_key()
+        if not user_info.get("is_premium", False):
+            console.print(
+                "[yellow]Warning:[/yellow] Premium membership required for direct downloads."
+            )
+            sys.exit(1)
+        console.print(f"[green]Authenticated as:[/green] {user_info.get('name')}")
+    except NexusAPIError as e:
+        console.print(f"[red]API Error:[/red] {e}")
+        sys.exit(1)
+
+    # Fetch mod info
+    try:
+        nexus_mod = api.get_mod_info(mod_info.game_domain, mod_info.mod_id)
+    except NexusAPIError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        sys.exit(1)
+
+    mod_name = nexus_mod.get("name", f"Mod {mod_info.mod_id}")
+    console.print(f"[bold]Name:[/bold] {mod_name}")
+
+    # Fetch file list
+    try:
+        files = api.get_mod_files(mod_info.game_domain, mod_info.mod_id)
+    except NexusAPIError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        sys.exit(1)
+
+    if not files:
+        console.print("[red]Error:[/red] No files found for this mod.")
+        sys.exit(1)
+
+    # Select file
+    selected = _select_mod_file(files, file_id)
+    if selected is None:
+        if file_id is not None:
+            console.print(f"[red]Error:[/red] File ID {file_id} not found.")
+        else:
+            console.print("[yellow]Could not auto-select a file. Available files:[/yellow]")
+        console.print()
+        table = Table(title="Available Files")
+        table.add_column("File ID", style="cyan")
+        table.add_column("Name")
+        table.add_column("Version")
+        table.add_column("Category")
+        table.add_column("Size")
+        category_names = {1: "Main", 2: "Update", 3: "Optional", 4: "Old", 5: "Misc", 6: "Archived"}
+        for f in files:
+            cat = category_names.get(f.get("category_id", 0), "Unknown")
+            size_kb = (f.get("size_in_bytes") or f.get("size", 0)) / 1024
+            size_str = f"{size_kb:.0f} KB" if size_kb < 1024 else f"{size_kb/1024:.1f} MB"
+            table.add_row(
+                str(f.get("file_id", "")),
+                f.get("name", f.get("file_name", "")),
+                f.get("version", "-"),
+                cat,
+                size_str,
+            )
+        console.print(table)
+        console.print("\nRe-run with --file-id to pick a specific file.")
+        sys.exit(1)
+
+    selected_file_id = selected["file_id"]
+    selected_name = selected.get("name", selected.get("file_name", ""))
+    selected_version = selected.get("version", "")
+    console.print(
+        f"[bold]File:[/bold] {selected_name} (ID: {selected_file_id}, v{selected_version})"
+    )
+
+    # Download
+    download_info = {
+        "mod_id": mod_info.mod_id,
+        "mod_name": mod_name,
+        "file_id": selected_file_id,
+        "filename": selected.get("file_name", selected_name),
+        "version": selected_version,
+        "size_bytes": selected.get("size_in_bytes") or selected.get("size", 0),
+        "optional": False,
+        "requirements": [],
+    }
+
+    console.print("\n[bold]Downloading...[/bold]")
+    downloader = Downloader(api)
+    results = downloader.download_mods(
+        game_domain=mod_info.game_domain,
+        mods=[download_info],
+        target_dir=mods_dir,
+    )
+
+    if not results:
+        console.print("[red]Error:[/red] Download failed.")
+        sys.exit(1)
+
+    # Extract
+    console.print("[bold]Extracting...[/bold]")
+    for _mod, file_path in results:
+        try:
+            if is_archive(file_path):
+                console.print(f"[dim]Extracting {file_path.name}...[/dim]")
+                extract_archive(file_path, mods_dir)
+                file_path.unlink()
+            else:
+                console.print(f"[dim]Installed {file_path.name}[/dim]")
+        except ExtractionError as e:
+            console.print(f"[red]Extraction error:[/red] {e}")
+            sys.exit(1)
+
+    # Register in state as manual
+    download_info["manual"] = True
+    state.add_mod(download_info)
+    state.mods[mod_info.mod_id].phase = 999
+    state.save()
+
+    console.print(f"[green]Added '{mod_name}' as manual mod (phase 999).[/green]")
+
+    # Regen load order
+    if not no_load_order:
+        console.print("\n[bold]Regenerating load order...[/bold]")
+        _regen_load_order_from_state(mods_dir, state)
+
+
+@main.command(name="add-local")
+@click.argument("name")
+@click.argument("mods_dir", type=click.Path(exists=True, path_type=Path))
+@click.option("--no-load-order", is_flag=True, help="Skip load order regeneration")
+@click.pass_context
+def add_local(
+    ctx: click.Context,
+    name: str,
+    mods_dir: Path,
+    no_load_order: bool,
+) -> None:
+    """
+    Register a local mod that's already in the mods directory.
+
+    NAME: Display name for the mod
+    MODS_DIR: Directory containing a previously synced collection
+    """
+    # Load existing state
+    state = CollectionState(mods_dir)
+    try:
+        state.load()
+    except StateError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        console.print("Run 'sync' first to download a collection.")
+        sys.exit(1)
+
+    # Generate synthetic negative mod_id
+    existing_ids = set(state.mods.keys())
+    synthetic_id = -1
+    while synthetic_id in existing_ids:
+        synthetic_id -= 1
+
+    mod_info = {
+        "mod_id": synthetic_id,
+        "mod_name": name,
+        "file_id": 0,
+        "filename": "",
+        "version": "",
+        "optional": False,
+        "manual": True,
+    }
+
+    state.add_mod(mod_info)
+    state.mods[synthetic_id].phase = 999
+    state.save()
+
+    console.print(
+        f"[green]Registered '{name}' as manual mod "
+        f"(ID: {synthetic_id}, phase 999).[/green]"
+    )
+
+    # Regen load order
+    if not no_load_order:
+        console.print("\n[bold]Regenerating load order...[/bold]")
+        _regen_load_order_from_state(mods_dir, state)
 
 
 if __name__ == "__main__":

--- a/nexus_collection_dl/collection.py
+++ b/nexus_collection_dl/collection.py
@@ -14,8 +14,23 @@ class CollectionInfo:
     url: str
 
 
+@dataclass
+class ModInfo:
+    """Parsed mod page URL information."""
+
+    game_domain: str
+    mod_id: int
+    url: str
+
+
 class CollectionParseError(Exception):
     """Raised when a collection URL cannot be parsed."""
+
+    pass
+
+
+class ModParseError(Exception):
+    """Raised when a mod URL cannot be parsed."""
 
     pass
 
@@ -57,5 +72,41 @@ def parse_collection_url(url: str) -> CollectionInfo:
     return CollectionInfo(
         game_domain=game_domain,
         slug=slug,
+        url=normalized_url,
+    )
+
+
+def parse_mod_url(url: str) -> ModInfo:
+    """
+    Parse a Nexus Mods mod page URL.
+
+    Supported formats:
+        - https://www.nexusmods.com/{game}/mods/{id}
+        - https://next.nexusmods.com/{game}/mods/{id}
+        - Either format with ?tab=... query params
+
+    Returns ModInfo with game_domain and mod_id.
+    """
+    parsed = urlparse(url)
+
+    if parsed.netloc not in ("next.nexusmods.com", "www.nexusmods.com", "nexusmods.com"):
+        raise ModParseError(
+            f"Invalid domain: {parsed.netloc}. Expected nexusmods.com"
+        )
+
+    path_match = re.match(r"^/([^/]+)/mods/(\d+)", parsed.path)
+    if not path_match:
+        raise ModParseError(
+            f"Invalid mod URL format: {url}\n"
+            "Expected: https://www.nexusmods.com/{{game}}/mods/{{id}}"
+        )
+
+    game_domain = path_match.group(1)
+    mod_id = int(path_match.group(2))
+    normalized_url = f"https://www.nexusmods.com/{game_domain}/mods/{mod_id}"
+
+    return ModInfo(
+        game_domain=game_domain,
+        mod_id=mod_id,
         url=normalized_url,
     )

--- a/nexus_collection_dl/deploy.py
+++ b/nexus_collection_dl/deploy.py
@@ -1,0 +1,427 @@
+"""Deploy mods from staging directory to game directory."""
+
+import re
+import shutil
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Bethesda plugin/archive extensions
+BETHESDA_EXTENSIONS = {".esm", ".esp", ".esl", ".ba2"}
+
+# Known asset directories that belong under Data/
+ASSET_DIRS = {
+    "geometries",
+    "textures",
+    "meshes",
+    "scripts",
+    "sound",
+    "materials",
+    "interface",
+    "video",
+    "terrain",
+    "strings",
+    "music",
+    "shadersfx",
+    "vis",
+    "seq",
+    "lodsettings",
+    "grass",
+    "facegen",
+    "dialogueviews",
+    "source",
+}
+
+# SFSE files that go in game root (not Data/)
+SFSE_ROOT_PATTERNS = {"sfse_loader.exe", "sfse_1_0_32.dll", "sfse_steam_loader.dll"}
+
+# Files/dirs to skip during deployment
+SKIP_PATTERNS = {
+    "fomod",
+    ".nexus-state.json",
+    "load-order.txt",
+    "plugins.txt",
+    "__folder_managed_by_vortex",
+}
+
+SKIP_EXTENSIONS = {".txt", ".md", ".jpg", ".jpeg", ".png", ".gif", ".pdf", ".log"}
+
+# Starfield INI settings for mod support
+GAME_INI_SETTINGS = {
+    "starfield": {
+        "filename": "StarfieldCustom.ini",
+        "sections": {
+            "Archive": {
+                "bInvalidateOlderFiles": "1",
+                "sResourceDataDirsFinal": "",
+            },
+        },
+    },
+    "skyrimspecialedition": {
+        "filename": "SkyrimCustom.ini",
+        "sections": {
+            "Archive": {
+                "bInvalidateOlderFiles": "1",
+                "sResourceDataDirsFinal": "",
+            },
+        },
+    },
+    "fallout4": {
+        "filename": "Fallout4Custom.ini",
+        "sections": {
+            "Archive": {
+                "bInvalidateOlderFiles": "1",
+                "sResourceDataDirsFinal": "",
+            },
+        },
+    },
+}
+
+# Game names for Proton Documents path
+GAME_DOC_NAMES = {
+    "starfield": "Starfield",
+    "skyrimspecialedition": "Skyrim Special Edition",
+    "fallout4": "Fallout4",
+}
+
+# Game names for Proton AppData/Local path
+GAME_APPDATA_NAMES = {
+    "starfield": "Starfield",
+    "skyrimspecialedition": "Skyrim Special Edition",
+    "fallout4": "Fallout4",
+}
+
+# Pattern for numbered option folders (e.g., "00 - Base", "01 - Main Files")
+NUMBERED_OPTION_RE = re.compile(r"^\d{2,3}\s*[-_]\s*")
+
+# Pattern for versioned SFSE directories (e.g., "sfse_0_2_18")
+SFSE_VERSION_DIR_RE = re.compile(r"^sfse_[\d_]+$", re.IGNORECASE)
+
+
+@dataclass
+class DeployedFile:
+    """Record of a single deployed file."""
+
+    src: str
+    dest: str
+    method: str  # "symlink" or "copy"
+
+    def to_dict(self) -> dict:
+        return {"src": self.src, "dest": self.dest, "method": self.method}
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "DeployedFile":
+        return cls(src=data["src"], dest=data["dest"], method=data["method"])
+
+
+@dataclass
+class DeploymentPlan:
+    """Classification of files to deploy."""
+
+    game_root_files: list[tuple[Path, Path]] = field(default_factory=list)
+    data_files: list[tuple[Path, Path]] = field(default_factory=list)
+    skipped: list[tuple[Path, str]] = field(default_factory=list)
+
+    @property
+    def total_files(self) -> int:
+        return len(self.game_root_files) + len(self.data_files)
+
+
+@dataclass
+class DeployResult:
+    """Result of a deployment operation."""
+
+    deployed: list[DeployedFile] = field(default_factory=list)
+    skipped: list[tuple[str, str]] = field(default_factory=list)
+    conflicts: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+
+
+def classify_file(rel_path: Path, game_domain: str) -> tuple[str, Path] | None:
+    """
+    Classify a single file and return (target_base, relative_dest) or None to skip.
+
+    target_base is "root" for game root or "data" for Data/ directory.
+    """
+    parts = rel_path.parts
+    name = rel_path.name
+    name_lower = name.lower()
+    suffix_lower = rel_path.suffix.lower()
+
+    # Skip metadata/docs
+    if name_lower in SKIP_PATTERNS or name_lower.startswith("readme"):
+        return None
+    if suffix_lower in SKIP_EXTENSIONS and suffix_lower not in BETHESDA_EXTENSIONS:
+        return None
+    if any(p.lower() in SKIP_PATTERNS for p in parts):
+        return None
+
+    # SFSE root files (sfse_loader.exe, sfse_*.dll) - deploy to game root
+    if name_lower.startswith("sfse_") and suffix_lower in (".exe", ".dll"):
+        return ("root", Path(name))
+
+    # Handle SFSE/Plugins/ at various depths
+    lower_parts = [p.lower() for p in parts]
+    if "sfse" in lower_parts:
+        sfse_idx = lower_parts.index("sfse")
+        remainder = Path(*parts[sfse_idx:])
+        # Strip leading "data/" if present
+        if lower_parts[0] == "data" and sfse_idx == 1:
+            return ("data", remainder)
+        elif sfse_idx == 0:
+            return ("data", remainder)
+
+    # Explicit Data/ prefix
+    if lower_parts[0] == "data" and len(parts) > 1:
+        remainder = Path(*parts[1:])
+        return ("data", remainder)
+
+    # Loose plugin/archive files at root
+    if len(parts) == 1 and suffix_lower in BETHESDA_EXTENSIONS:
+        return ("data", Path(name))
+
+    # Known asset directories at root level
+    if lower_parts[0] in ASSET_DIRS:
+        return ("data", rel_path)
+
+    # Any other file - try to deploy under Data/
+    # This catches things like Meshes/, Textures/ nested inside subdirs
+    for i, part_lower in enumerate(lower_parts):
+        if part_lower in ASSET_DIRS:
+            return ("data", Path(*parts[i:]))
+
+    # If it's a DLL at root, might be an SFSE plugin or ASI loader
+    if len(parts) == 1 and suffix_lower == ".dll":
+        return ("root", Path(name))
+
+    # INI files at root - could be game config
+    if len(parts) == 1 and suffix_lower == ".ini":
+        return ("root", Path(name))
+
+    # Unknown file - deploy under Data/ as fallback for anything with
+    # a game-relevant extension, skip otherwise
+    return ("data", rel_path)
+
+
+def classify_files(mods_dir: Path, game_domain: str) -> DeploymentPlan:
+    """Walk the staging directory and classify all files for deployment."""
+    plan = DeploymentPlan()
+
+    for file_path in sorted(mods_dir.rglob("*")):
+        if not file_path.is_file():
+            continue
+
+        rel = file_path.relative_to(mods_dir)
+        parts = rel.parts
+
+        # Skip hidden/tool files at root
+        if parts[0].startswith("."):
+            plan.skipped.append((rel, "hidden file"))
+            continue
+
+        # Strip wrapper directories (numbered options, SFSE version dirs)
+        effective_parts = list(parts)
+        while effective_parts and (
+            NUMBERED_OPTION_RE.match(effective_parts[0])
+            or SFSE_VERSION_DIR_RE.match(effective_parts[0])
+        ):
+            effective_parts = effective_parts[1:]
+
+        if not effective_parts:
+            plan.skipped.append((rel, "empty after stripping option folders"))
+            continue
+
+        effective_rel = Path(*effective_parts)
+        result = classify_file(effective_rel, game_domain)
+
+        if result is None:
+            plan.skipped.append((rel, "metadata/docs"))
+            continue
+
+        target_base, dest_rel = result
+        if target_base == "root":
+            plan.game_root_files.append((file_path, dest_rel))
+        else:
+            plan.data_files.append((file_path, dest_rel))
+
+    return plan
+
+
+def _deploy_file(src: Path, dest: Path, method: str) -> None:
+    """Deploy a single file via symlink or copy."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    if dest.is_symlink() or dest.exists():
+        if dest.is_symlink():
+            dest.unlink()
+        elif dest.is_file():
+            dest.unlink()
+
+    if method == "symlink":
+        dest.symlink_to(src.resolve())
+    else:
+        shutil.copy2(src, dest)
+
+
+def deploy(
+    plan: DeploymentPlan,
+    game_dir: Path,
+    method: str = "symlink",
+    dry_run: bool = False,
+) -> DeployResult:
+    """Execute a deployment plan."""
+    result = DeployResult()
+    data_dir = game_dir / "Data"
+
+    # Deploy game root files (SFSE, root DLLs)
+    for src, dest_rel in plan.game_root_files:
+        dest = game_dir / dest_rel
+        if dry_run:
+            result.deployed.append(DeployedFile(str(src), str(dest), method))
+            continue
+        try:
+            _deploy_file(src, dest, method)
+            result.deployed.append(DeployedFile(str(src), str(dest), method))
+        except OSError as e:
+            result.errors.append(f"{dest_rel}: {e}")
+
+    # Deploy Data/ files
+    seen_dests: dict[Path, Path] = {}
+    for src, dest_rel in plan.data_files:
+        dest = data_dir / dest_rel
+
+        # Track conflicts (multiple sources -> same dest)
+        if dest in seen_dests:
+            result.conflicts.append(
+                f"{dest_rel}: overwritten by {src.name} (was {seen_dests[dest].name})"
+            )
+        seen_dests[dest] = src
+
+        if dry_run:
+            result.deployed.append(DeployedFile(str(src), str(dest), method))
+            continue
+        try:
+            _deploy_file(src, dest, method)
+            result.deployed.append(DeployedFile(str(src), str(dest), method))
+        except OSError as e:
+            result.errors.append(f"{dest_rel}: {e}")
+
+    return result
+
+
+def undeploy(deployed_files: list[dict]) -> int:
+    """Remove all deployed files. Returns count of files removed."""
+    removed = 0
+    for entry in deployed_files:
+        dest = Path(entry["dest"])
+        if dest.is_symlink() or dest.exists():
+            try:
+                dest.unlink()
+                removed += 1
+                # Clean up empty parent dirs up to Data/ or game root
+                _cleanup_empty_parents(dest.parent)
+            except OSError:
+                pass
+    return removed
+
+
+def _cleanup_empty_parents(directory: Path) -> None:
+    """Remove empty parent directories, stopping at Data/ or game root."""
+    try:
+        while directory.name and directory.name not in ("Data", "data"):
+            if not any(directory.iterdir()):
+                directory.rmdir()
+                directory = directory.parent
+            else:
+                break
+    except OSError:
+        pass
+
+
+def write_plugins_txt(src: Path, dest: Path) -> bool:
+    """Copy plugins.txt from staging dir to game's AppData path."""
+    if not src.exists():
+        return False
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dest)
+    return True
+
+
+def write_game_ini(ini_path: Path, game_domain: str) -> bool:
+    """Create or update the game's custom INI file for mod support."""
+    settings = GAME_INI_SETTINGS.get(game_domain)
+    if not settings:
+        return False
+
+    ini_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Read existing content if present
+    existing_lines = []
+    if ini_path.exists():
+        existing_lines = ini_path.read_text().splitlines()
+
+    # Parse existing sections
+    existing_sections: dict[str, dict[str, str]] = {}
+    current_section = ""
+    for line in existing_lines:
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            current_section = stripped[1:-1]
+            existing_sections.setdefault(current_section, {})
+        elif "=" in stripped and current_section:
+            key, _, value = stripped.partition("=")
+            existing_sections[current_section][key.strip()] = value.strip()
+
+    # Merge our required settings
+    for section, keys in settings["sections"].items():
+        existing_sections.setdefault(section, {})
+        for key, value in keys.items():
+            existing_sections[section][key] = value
+
+    # Write back
+    lines = []
+    for section, keys in existing_sections.items():
+        lines.append(f"[{section}]")
+        for key, value in keys.items():
+            lines.append(f"{key}={value}")
+        lines.append("")
+
+    ini_path.write_text("\n".join(lines))
+    return True
+
+
+def get_plugins_txt_dest(prefix: Path, game_domain: str) -> Path | None:
+    """Get the destination path for plugins.txt in the Proton prefix."""
+    appdata_name = GAME_APPDATA_NAMES.get(game_domain)
+    if not appdata_name:
+        return None
+    return (
+        prefix
+        / "drive_c"
+        / "users"
+        / "steamuser"
+        / "AppData"
+        / "Local"
+        / appdata_name
+        / "plugins.txt"
+    )
+
+
+def get_game_ini_path(prefix: Path, game_domain: str) -> Path | None:
+    """Get the destination path for the game's custom INI in the Proton prefix."""
+    doc_name = GAME_DOC_NAMES.get(game_domain)
+    if not doc_name:
+        return None
+    ini_settings = GAME_INI_SETTINGS.get(game_domain)
+    if not ini_settings:
+        return None
+    return (
+        prefix
+        / "drive_c"
+        / "users"
+        / "steamuser"
+        / "Documents"
+        / "My Games"
+        / doc_name
+        / ini_settings["filename"]
+    )

--- a/nexus_collection_dl/steam.py
+++ b/nexus_collection_dl/steam.py
@@ -1,0 +1,96 @@
+"""Steam library detection and game path resolution."""
+
+import re
+from pathlib import Path
+
+
+# Map Nexus game domains to Steam app IDs
+STEAM_APP_IDS = {
+    "starfield": "1716740",
+    "skyrimspecialedition": "489830",
+    "fallout4": "377160",
+    "falloutnewvegas": "22380",
+    "fallout3": "22300",
+    "oblivion": "22330",
+    "morrowind": "22320",
+    "enderal": "933480",
+    "enderalspecialedition": "976620",
+}
+
+# Common Steam install locations on Linux
+STEAM_PATHS = [
+    Path.home() / ".steam" / "debian-installation",
+    Path.home() / ".steam" / "steam",
+    Path.home() / ".local" / "share" / "Steam",
+    Path("/usr/share/steam"),
+]
+
+
+def find_steam_root() -> Path | None:
+    """Find the Steam installation root directory."""
+    for path in STEAM_PATHS:
+        vdf = path / "config" / "libraryfolders.vdf"
+        if vdf.exists():
+            return path
+    return None
+
+
+def parse_library_folders(steam_root: Path) -> list[Path]:
+    """Parse libraryfolders.vdf to get all Steam library paths."""
+    vdf_path = steam_root / "config" / "libraryfolders.vdf"
+    if not vdf_path.exists():
+        return []
+
+    text = vdf_path.read_text()
+    # Match "path" values in Valve KV1 format
+    paths = []
+    for match in re.finditer(r'"path"\s+"([^"]+)"', text):
+        lib_path = Path(match.group(1))
+        if lib_path.exists():
+            paths.append(lib_path)
+
+    return paths
+
+
+def find_game_dir(game_domain: str) -> Path | None:
+    """Find the game install directory by searching Steam libraries."""
+    app_id = STEAM_APP_IDS.get(game_domain)
+    if not app_id:
+        return None
+
+    steam_root = find_steam_root()
+    if not steam_root:
+        return None
+
+    libraries = parse_library_folders(steam_root)
+    for lib_path in libraries:
+        manifest = lib_path / "steamapps" / f"appmanifest_{app_id}.acf"
+        if manifest.exists():
+            # Parse installdir from manifest
+            text = manifest.read_text()
+            match = re.search(r'"installdir"\s+"([^"]+)"', text)
+            if match:
+                game_dir = lib_path / "steamapps" / "common" / match.group(1)
+                if game_dir.exists():
+                    return game_dir
+
+    return None
+
+
+def find_proton_prefix(game_domain: str) -> Path | None:
+    """Find the Proton/Wine prefix for a game."""
+    app_id = STEAM_APP_IDS.get(game_domain)
+    if not app_id:
+        return None
+
+    steam_root = find_steam_root()
+    if not steam_root:
+        return None
+
+    libraries = parse_library_folders(steam_root)
+    for lib_path in libraries:
+        prefix = lib_path / "steamapps" / "compatdata" / app_id / "pfx"
+        if prefix.exists():
+            return prefix
+
+    return None


### PR DESCRIPTION
## Summary
- Add `nexus-dl add <mod_url> <mods_dir>` to download individual mods by URL and track them as manual mods (phase 999)
- Add `nexus-dl add-local <name> <mods_dir>` to register already-present mods with synthetic negative IDs
- Manual mods are protected from removal during collection updates via `manual` flag in state
- Also includes deploy/undeploy commands and Steam game directory detection

## Test plan
- [ ] `nexus-dl add "https://www.nexusmods.com/starfield/mods/123" ~/mods/starfield` downloads, extracts, registers
- [ ] `nexus-dl add "..." ~/mods/starfield --file-id 456` picks specific file
- [ ] `nexus-dl add-local "My Custom Mod" ~/mods/starfield` registers with negative ID
- [ ] `nexus-dl update ~/mods/starfield --dry-run` - manual mods NOT in "to remove" list
- [ ] Load-order.txt shows manual mods at end (phase 999)

🤖 Generated with [Claude Code](https://claude.com/claude-code)