### PR TITLE
feat: tracked-mod sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,23 @@ nexus-dl add-local "My Custom Mod" ~/mods/starfield
 
 Registers an already-present mod that you placed in the mods directory manually. Useful for custom patches, merged plugins, or mods from other sources. Like `add`, these are tracked as manual mods and won't be removed by `update`.
 
+### Tracked-mod sync
+
+```bash
+# Enable - syncs tracked mods on Nexus to match your local loadout
+nexus-dl track-sync enable ~/mods/starfield
+
+# Disable - stops future syncs, leaves existing tracked mods alone
+nexus-dl track-sync disable ~/mods/starfield
+
+# One-shot manual push (works regardless of enable/disable)
+nexus-dl track-sync push ~/mods/starfield
+```
+
+When enabled, the "tracked" bell icon on nexusmods.com mirrors your local mod list. After `sync`, `update`, `add`, or `add-local`, tracked mods are automatically updated so browsing the site shows which mods you already have installed.
+
+Opt-in only - won't touch your tracked mods unless you explicitly enable it. Disabling preserves whatever's currently tracked on Nexus. Only affects mods for the collection's game domain (your tracked Skyrim mods are safe when syncing a Starfield collection). Local-only mods (from `add-local`) are skipped since they don't have Nexus mod IDs.
+
 ### Remove deployed mods
 
 ```bash
@@ -205,6 +222,7 @@ Masterlists are cached in `~/.cache/nexus-dl/masterlists/` and refreshed every 2
 - **add-local** - Registers an already-present mod in the state without downloading anything.
 - **deploy** - Classifies files by type and symlinks (or copies) them to the correct game directory locations. Handles SFSE, Data/ assets, plugins, and Proton config files.
 - **undeploy** - Removes all deployed files using the tracked manifest, restoring the game directory.
+- **track-sync** - Manages Nexus tracked-mod sync (enable/disable/push). When enabled, the tracked bell icon on the website matches your local loadout.
 - **load-order** - Regenerates load order from the cached manifest (no API call needed).
 - **status** - Shows what's installed and whether updates are available.
 

--- a/nexus_collection_dl/api.py
+++ b/nexus_collection_dl/api.py
@@ -57,7 +57,7 @@ class NexusAPI:
             time.sleep(self._min_request_interval - elapsed)
         self._last_request_time = time.time()
 
-    def _handle_response(self, response: requests.Response) -> dict[str, Any]:
+    def _handle_response(self, response: requests.Response) -> Any:
         """Handle API response and raise appropriate errors."""
         if response.status_code == 429:
             retry_after = int(response.headers.get("Retry-After", 60))
@@ -230,3 +230,24 @@ class NexusAPI:
         url = f"{REST_BASE_URL}/users/validate.json"
         response = self.session.get(url)
         return self._handle_response(response)
+
+    def get_tracked_mods(self) -> list[dict[str, Any]]:
+        """Get all mods tracked by the current user."""
+        self._rate_limit_wait()
+        url = f"{REST_BASE_URL}/user/tracked_mods.json"
+        response = self.session.get(url)
+        return self._handle_response(response)
+
+    def track_mod(self, game_domain: str, mod_id: int) -> None:
+        """Add a mod to the user's tracked list."""
+        self._rate_limit_wait()
+        url = f"{REST_BASE_URL}/user/tracked_mods.json"
+        response = self.session.post(url, data={"domain_name": game_domain, "mod_id": mod_id})
+        self._handle_response(response)
+
+    def untrack_mod(self, game_domain: str, mod_id: int) -> None:
+        """Remove a mod from the user's tracked list."""
+        self._rate_limit_wait()
+        url = f"{REST_BASE_URL}/user/tracked_mods.json"
+        response = self.session.delete(url, data={"domain_name": game_domain, "mod_id": mod_id})
+        self._handle_response(response)

--- a/nexus_collection_dl/state.py
+++ b/nexus_collection_dl/state.py
@@ -91,6 +91,7 @@ class CollectionState:
         self.proton_prefix: str = ""
         self.deployed_files: list[dict] = []
         self.deployed_at: str | None = None
+        self.track_sync_enabled: bool = False
 
     def exists(self) -> bool:
         """Check if state file exists."""
@@ -117,6 +118,7 @@ class CollectionState:
         self.proton_prefix = data.get("proton_prefix", "")
         self.deployed_files = data.get("deployed_files", [])
         self.deployed_at = data.get("deployed_at")
+        self.track_sync_enabled = data.get("track_sync_enabled", False)
 
         self.mods = {}
         for mod_id_str, mod_data in data.get("mods", {}).items():
@@ -139,6 +141,7 @@ class CollectionState:
             "proton_prefix": self.proton_prefix,
             "deployed_files": self.deployed_files,
             "deployed_at": self.deployed_at,
+            "track_sync_enabled": self.track_sync_enabled,
         }
 
         with open(self.state_file, "w") as f:


### PR DESCRIPTION
## Summary

- Adds `track-sync` command group (enable/disable/push) to sync Nexus tracked mods with local loadout
- Tracked bell icon on nexusmods.com mirrors what's installed locally
- Auto-syncs after `sync`, `update`, `add`, and `add-local` when enabled
- Opt-in, game-scoped, skips synthetic IDs from `add-local`, graceful failure on errors

## Test plan

- [ ] `nexus-dl track-sync enable ~/mods/starfield` - enables and runs initial push
- [ ] `nexus-dl sync <url> ~/mods/starfield` - tracked mods match installed set after sync
- [ ] `nexus-dl add <url> ~/mods/starfield` - new mod appears as tracked
- [ ] `nexus-dl track-sync push ~/mods/starfield` - manual one-shot sync
- [ ] `nexus-dl track-sync disable ~/mods/starfield` - disables without untracking
- [ ] Verify nexusmods.com bell icons match local loadout

🤖 Generated with [Claude Code](https://claude.com/claude-code)