### PR TITLE
feat: add --no-extract flag to skip archive extraction

### DIFF
--- a/nexus_collection_dl/cli.py
+++ b/nexus_collection_dl/cli.py
@@ -39,6 +39,7 @@ def _cli_progress(event: str, pct: float, msg: str) -> None:
 @click.argument("mods_dir", type=click.Path(path_type=Path))
 @click.option("--skip-optional", is_flag=True, help="Skip optional mods")
 @click.option("--no-load-order", is_flag=True, help="Skip load order generation")
+@click.option("--no-extract", is_flag=True, help="Keep downloaded archives without extracting")
 @click.pass_context
 def sync(
     ctx: click.Context,
@@ -46,6 +47,7 @@ def sync(
     mods_dir: Path,
     skip_optional: bool,
     no_load_order: bool,
+    no_extract: bool,
 ) -> None:
     """
     Download a collection to the specified directory.
@@ -59,6 +61,7 @@ def sync(
             collection_url, mods_dir,
             skip_optional=skip_optional,
             no_load_order=no_load_order,
+            no_extract=no_extract,
             on_progress=_cli_progress,
         )
     except (NexusAPIError, CollectionParseError, StateError) as e:
@@ -85,6 +88,7 @@ def sync(
 @click.option("--skip-optional", is_flag=True, help="Skip optional mods")
 @click.option("--dry-run", is_flag=True, help="Show what would be updated without downloading")
 @click.option("--no-load-order", is_flag=True, help="Skip load order generation")
+@click.option("--no-extract", is_flag=True, help="Keep downloaded archives without extracting")
 @click.pass_context
 def update(
     ctx: click.Context,
@@ -92,6 +96,7 @@ def update(
     skip_optional: bool,
     dry_run: bool,
     no_load_order: bool,
+    no_extract: bool,
 ) -> None:
     """
     Check for and download updated mods.
@@ -142,6 +147,7 @@ def update(
             mods_dir,
             skip_optional=skip_optional,
             no_load_order=no_load_order,
+            no_extract=no_extract,
             on_progress=_cli_progress,
         )
     except (NexusAPIError, CollectionParseError, StateError) as e:
@@ -354,6 +360,7 @@ def undeploy(ctx: click.Context, mods_dir: Path) -> None:
 @click.argument("mods_dir", type=click.Path(exists=True, path_type=Path))
 @click.option("--file-id", type=int, default=None, help="Specific file ID to download")
 @click.option("--no-load-order", is_flag=True, help="Skip load order regeneration")
+@click.option("--no-extract", is_flag=True, help="Keep downloaded archives without extracting")
 @click.pass_context
 def add(
     ctx: click.Context,
@@ -361,6 +368,7 @@ def add(
     mods_dir: Path,
     file_id: int | None,
     no_load_order: bool,
+    no_extract: bool,
 ) -> None:
     """
     Add a single mod by URL.
@@ -374,6 +382,7 @@ def add(
             mod_url, mods_dir,
             file_id=file_id,
             no_load_order=no_load_order,
+            no_extract=no_extract,
             on_progress=_cli_progress,
         )
     except (NexusAPIError, ModParseError, StateError) as e:

--- a/nexus_collection_dl/service.py
+++ b/nexus_collection_dl/service.py
@@ -254,6 +254,7 @@ class ModManagerService:
         mods_dir: Path,
         skip_optional: bool = False,
         no_load_order: bool = False,
+        no_extract: bool = False,
         on_progress: ProgressCallback | None = None,
     ) -> SyncResult:
         """Download an entire collection."""
@@ -316,7 +317,7 @@ class ModManagerService:
         extracted = 0
         for i, (mod_info, file_path) in enumerate(results):
             try:
-                if is_archive(file_path):
+                if not no_extract and is_archive(file_path):
                     extract_archive(file_path, mods_dir)
                     file_path.unlink()
                     extracted += 1
@@ -352,6 +353,7 @@ class ModManagerService:
         mods_dir: Path,
         skip_optional: bool = False,
         no_load_order: bool = False,
+        no_extract: bool = False,
         on_progress: ProgressCallback | None = None,
     ) -> UpdateResult:
         """Check for and download updates."""
@@ -401,7 +403,7 @@ class ModManagerService:
             progress("extract", 0.75, "Extracting archives...")
             for mod_info, file_path in results:
                 try:
-                    if is_archive(file_path):
+                    if not no_extract and is_archive(file_path):
                         extract_archive(file_path, mods_dir)
                         file_path.unlink()
                     state.add_mod(mod_info)
@@ -438,6 +440,7 @@ class ModManagerService:
         mods_dir: Path,
         file_id: int | None = None,
         no_load_order: bool = False,
+        no_extract: bool = False,
         on_progress: ProgressCallback | None = None,
     ) -> AddResult:
         """Add a single mod by Nexus URL."""
@@ -521,7 +524,7 @@ class ModManagerService:
         progress("extract", 0.85, "Extracting...")
         for _mod, file_path in results:
             try:
-                if is_archive(file_path):
+                if not no_extract and is_archive(file_path):
                     extract_archive(file_path, mods_dir)
                     file_path.unlink()
             except ExtractionError as e:

--- a/nexus_collection_dl/web/app.py
+++ b/nexus_collection_dl/web/app.py
@@ -74,6 +74,7 @@ def create_app(api_key: str | None = None, mods_dir: Path | None = None) -> Flas
         data = request.get_json(silent=True) or {}
         collection_url = data.get("collection_url", "")
         skip_optional = data.get("skip_optional", False)
+        no_extract = data.get("no_extract", False)
 
         if not collection_url:
             return jsonify({"error": "collection_url is required"}), 400
@@ -89,6 +90,7 @@ def create_app(api_key: str | None = None, mods_dir: Path | None = None) -> Flas
             return svc.sync(
                 collection_url, mods_path,
                 skip_optional=skip_optional,
+                no_extract=no_extract,
                 on_progress=progress_cb,
             )
 
@@ -99,6 +101,7 @@ def create_app(api_key: str | None = None, mods_dir: Path | None = None) -> Flas
     def api_update():
         data = request.get_json(silent=True) or {}
         skip_optional = data.get("skip_optional", False)
+        no_extract = data.get("no_extract", False)
 
         task_id = tasks.create("update")
         svc = get_service()
@@ -108,7 +111,7 @@ def create_app(api_key: str | None = None, mods_dir: Path | None = None) -> Flas
             tasks.update_progress(task_id, pct, msg)
 
         def run():
-            return svc.update(mods_path, skip_optional=skip_optional, on_progress=progress_cb)
+            return svc.update(mods_path, skip_optional=skip_optional, no_extract=no_extract, on_progress=progress_cb)
 
         tasks.run_in_background(task_id, run)
         return jsonify({"task_id": task_id}), 202
@@ -118,6 +121,7 @@ def create_app(api_key: str | None = None, mods_dir: Path | None = None) -> Flas
         data = request.get_json(silent=True) or {}
         mod_url = data.get("mod_url", "")
         file_id = data.get("file_id")
+        no_extract = data.get("no_extract", False)
 
         if not mod_url:
             return jsonify({"error": "mod_url is required"}), 400
@@ -133,7 +137,7 @@ def create_app(api_key: str | None = None, mods_dir: Path | None = None) -> Flas
             tasks.update_progress(task_id, pct, msg)
 
         def run():
-            return svc.add_mod(mod_url, mods_path, file_id=file_id, on_progress=progress_cb)
+            return svc.add_mod(mod_url, mods_path, file_id=file_id, no_extract=no_extract, on_progress=progress_cb)
 
         tasks.run_in_background(task_id, run)
         return jsonify({"task_id": task_id}), 202


### PR DESCRIPTION
## Summary

- Adds `--no-extract` flag to `sync`, `update`, and `add` CLI commands
- When passed, downloaded archives are kept intact instead of being extracted and deleted
- Useful for users with third-party mod managers (e.g. Stardrop for Stardew Valley) that manage their own extraction
- Web API routes (`/api/sync`, `/api/update`, `/api/add`) also support `no_extract` in the JSON request body

## Changes

- `nexus_collection_dl/cli.py` - added `--no-extract` option decorator and parameter to `sync`, `update`, and `add` commands; passes `no_extract=no_extract` through to service calls
- `nexus_collection_dl/service.py` - added `no_extract: bool = False` parameter to `sync()`, `update()`, and `add_mod()`; wraps extraction blocks with `if not no_extract:`
- `nexus_collection_dl/web/app.py` - reads `no_extract` from request JSON and passes it to all three service calls

## Test plan

- [ ] `nexus-dl sync --help` shows `--no-extract` flag
- [ ] `nexus-dl update --help` shows `--no-extract` flag
- [ ] `nexus-dl add --help` shows `--no-extract` flag
- [ ] Running `sync --no-extract` leaves archive files in the mods directory unextracted
- [ ] Running without `--no-extract` behaves exactly as before

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)