### PR TITLE
Add community health files and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,80 @@
+name: Bug Report
+description: Something isn't working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting this. Please fill out the sections below so we can reproduce the issue.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+      placeholder: "When I run `nexus-dl sync ...`, it fails with ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: What commands or actions trigger the bug?
+      placeholder: |
+        1. Run `nexus-dl sync "https://..." ~/mods/starfield`
+        2. Wait for downloads to complete
+        3. See error in terminal
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened instead?
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: nexus-dl version
+      description: "Run `nexus-dl --version` or `pip show nexus-collection-dl`"
+      placeholder: "0.1.0"
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Installation method
+      options:
+        - Docker
+        - setup.sh
+        - Manual (pip install)
+
+  - type: input
+    id: os
+    attributes:
+      label: OS
+      placeholder: "Ubuntu 24.04 / Fedora 41 / macOS 15"
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      placeholder: "3.12"
+
+  - type: dropdown
+    id: account-type
+    attributes:
+      label: Nexus Mods account type
+      options:
+        - Premium
+        - Free
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Paste any error messages or tracebacks here.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Help
+    url: https://github.com/scottmccarrison/nexus-collection-dl/discussions/categories/q-a
+    about: Ask questions and get help in Discussions. Issues are for bugs and feature requests.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,31 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea for something new? Describe it below.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What would you like to see?
+      description: A clear description of the feature.
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: Why do you need this? What problem does it solve?
+      placeholder: "I'm trying to ... but currently I have to ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Have you tried any workarounds or other approaches?

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,30 @@
+# Code of Conduct
+
+## Our pledge
+
+We are committed to making participation in this project a welcoming experience for everyone, regardless of background or identity.
+
+## Our standards
+
+**Positive behavior includes:**
+
+- Being respectful and constructive
+- Accepting feedback gracefully
+- Focusing on what's best for the community
+- Showing empathy toward others
+
+**Unacceptable behavior includes:**
+
+- Harassment, trolling, or personal attacks
+- Publishing others' private information without consent
+- Any conduct that would be considered inappropriate in a professional setting
+
+## Enforcement
+
+Instances of unacceptable behavior can be reported by opening an issue or contacting the maintainer through [Discussions](https://github.com/scottmccarrison/nexus-collection-dl/discussions). All complaints will be reviewed and addressed.
+
+Project maintainers may remove, edit, or reject comments, commits, issues, and other contributions that violate this code of conduct. Repeat offenders may be temporarily or permanently banned.
+
+## Attribution
+
+This code of conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing
+
+Thanks for your interest in contributing to nexus-collection-dl.
+
+## Reporting bugs
+
+Use the [Bug Report](https://github.com/scottmccarrison/nexus-collection-dl/issues/new?template=bug_report.yml) issue template. Include steps to reproduce, your OS, Python version, and any error output. The more detail, the faster we can fix it.
+
+## Suggesting features
+
+Use the [Feature Request](https://github.com/scottmccarrison/nexus-collection-dl/issues/new?template=feature_request.yml) issue template. Describe the feature and why you need it.
+
+## Asking questions
+
+Head to [Discussions](https://github.com/scottmccarrison/nexus-collection-dl/discussions) for questions, troubleshooting, and general conversation. Issues are for bugs and feature requests only.
+
+## Development setup
+
+```bash
+git clone https://github.com/scottmccarrison/nexus-collection-dl.git
+cd nexus-collection-dl
+./setup.sh
+source venv/bin/activate
+```
+
+You'll need a Nexus Mods API key to test against the API. See the [README](README.md#setup) for details.
+
+## Pull requests
+
+- Create a feature branch off `main`
+- Use a descriptive branch name (e.g., `fix-rar-extraction`, `add-dry-run-flag`)
+- Keep changes focused. One PR per feature or fix.
+- Link the related issue if there is one
+- Test your changes locally before submitting
+
+That's it. Nothing complicated.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest version is supported. If you find a vulnerability, make sure you're on the current release before reporting.
+
+## Reporting a vulnerability
+
+**Do not open a public issue for security vulnerabilities.**
+
+Instead, use one of these:
+
+1. **GitHub Security Advisory** (preferred): Go to the [Security tab](https://github.com/scottmccarrison/nexus-collection-dl/security/advisories/new) and create a private advisory.
+2. **Email**: Reach out to the maintainer directly (see GitHub profile).
+
+Include as much detail as possible: what the vulnerability is, how to reproduce it, and what impact it has.
+
+You should get a response within a few days. If the issue is confirmed, a fix will be prioritized and released as soon as practical.
+
+## Scope
+
+This policy covers the nexus-collection-dl tool itself. Issues with the Nexus Mods API, Nexus Mods website, or third-party dependencies should be reported to their respective maintainers.


### PR DESCRIPTION
## Summary

- Issue templates: structured bug report form and feature request form
- Config: blank issues disabled, questions redirected to Discussions Q&A
- CONTRIBUTING.md: how to report bugs, suggest features, ask questions, and submit PRs
- CODE_OF_CONDUCT.md: adapted from Contributor Covenant v2.1
- SECURITY.md: how to report vulnerabilities (private advisory or email, not public issues)

## Test plan

- [ ] Visit repo issues page - should show template chooser with no blank issue option
- [ ] "Questions & Help" link should point to Discussions Q&A
- [ ] Community health files visible on repo Insights > Community Standards


🤖 Generated with [Claude Code](https://claude.com/claude-code)