### PR TITLE
Fix CLI download progress spamming terminal

### DIFF
--- a/nexus_collection_dl/cli.py
+++ b/nexus_collection_dl/cli.py
@@ -38,6 +38,8 @@ def main(ctx: click.Context, api_key: str | None, free: bool) -> None:
 
 def _cli_progress(event: str, pct: float, msg: str) -> None:
     """Print progress messages to Rich console."""
+    if event == "download":
+        return  # Rich progress bar in downloader.py handles this
     console.print(f"[dim]{msg}[/dim]")
 
 


### PR DESCRIPTION
## Summary
- Skip `download` events in `_cli_progress` callback since the Rich progress bar in `downloader.py` already handles in-place download display
- Eliminates ~31,000 lines of spam per 256MB download

## Test plan
- [ ] Run `nexus-dl sync` or `nexus-dl update` with a collection and verify clean progress bars without line spam
- [ ] Verify non-download progress events (extracting, classifying) still print normally

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)