### PR TITLE
Deduplicate mods by mod_id to prevent redundant downloads

### DIFF
--- a/nexus_collection_dl/api.py
+++ b/nexus_collection_dl/api.py
@@ -181,11 +181,22 @@ class NexusAPI:
                 }
             )
 
+        # Deduplicate by mod_id, keeping the last occurrence so the
+        # collection's intended load order wins when the same mod appears
+        # multiple times (patches, updates, revised entries).
+        seen: dict[int, int] = {}
+        for i, mod in enumerate(mods):
+            seen[mod["mod_id"]] = i
+        unique_indices = set(seen.values())
+        dupes_removed = len(mods) - len(unique_indices)
+        mods = [m for i, m in enumerate(mods) if i in unique_indices]
+
         return {
             "id": collection.get("id"),
             "slug": collection.get("slug"),
             "name": collection.get("name"),
             "summary": collection.get("summary"),
+            "duplicates_removed": dupes_removed,
             "game_domain": actual_game,
             "revision": revision.get("revisionNumber"),
             "download_link": download_link,

--- a/nexus_collection_dl/service.py
+++ b/nexus_collection_dl/service.py
@@ -311,6 +311,9 @@ class ModManagerService:
         )
 
         mods = collection_data["mods"]
+        dupes = collection_data.get("duplicates_removed", 0)
+        if dupes:
+            progress("fetch", 0.06, f"Deduplicated {dupes} duplicate mod entries")
         if skip_optional:
             mods = [m for m in mods if not m.get("optional", False)]
 
@@ -456,6 +459,9 @@ class ModManagerService:
 
         new_revision = collection_data["revision"]
         mods = collection_data["mods"]
+        dupes = collection_data.get("duplicates_removed", 0)
+        if dupes:
+            progress("fetch", 0.06, f"Deduplicated {dupes} duplicate mod entries")
         if skip_optional:
             mods = [m for m in mods if not m.get("optional", False)]
 


### PR DESCRIPTION
## Summary
- Deduplicate the mod list in `get_collection_mods()` by `mod_id`, keeping the last occurrence to preserve the collection's intended load order
- Log a message when duplicates are removed so users know it happened
- Affects both `sync` and `update` paths since dedup happens at the API layer

This should reduce download times for collections with duplicate entries and cut down on misleading deploy conflict counts (e.g. `Weapons of Fate.esm` conflicting with itself).

## Test plan
- [ ] Run `nexus-dl sync` on a collection known to have duplicate mod_ids and verify no redundant downloads
- [ ] Verify the "Deduplicated N duplicate mod entries" message appears when dupes exist
- [ ] Run `nexus-dl deploy` after sync and confirm reduced self-conflict count
- [ ] Run `nexus-dl update` and verify dedup works on that path too

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)