### PR TITLE
Filter unselected FOMOD option folders during deploy

### DIFF
--- a/nexus_collection_dl/cli.py
+++ b/nexus_collection_dl/cli.py
@@ -335,7 +335,13 @@ def deploy(
             console.print("[red]Error:[/red] Could not find game directory.")
             sys.exit(1)
 
-        plan = classify_files(mods_dir, state.game_domain)
+        # Load manifest choices for FOMOD filtering
+        manifest_choices = {}
+        if state.manifest_data:
+            from .manifest import CollectionManifest
+            manifest = CollectionManifest.from_dict(state.manifest_data)
+            manifest_choices = manifest.mod_choices
+        plan = classify_files(mods_dir, state.game_domain, mod_choices=manifest_choices)
         console.print(f"  Game root files: {len(plan.game_root_files)}")
         console.print(f"  Data files: {len(plan.data_files)}")
         console.print(f"  Skipped: {len(plan.skipped)}")

--- a/nexus_collection_dl/deploy.py
+++ b/nexus_collection_dl/deploy.py
@@ -203,8 +203,11 @@ def classify_file(rel_path: Path, game_domain: str) -> tuple[str, Path] | None:
     return ("data", rel_path)
 
 
-def classify_files(mods_dir: Path, game_domain: str) -> DeploymentPlan:
+def classify_files(mods_dir: Path, game_domain: str, mod_choices: dict[int, dict] | None = None) -> DeploymentPlan:
     """Walk the staging directory and classify all files for deployment."""
+    from .fomod import build_fomod_skip_set
+    fomod_skip = build_fomod_skip_set(mods_dir, mod_choices or {})
+
     plan = DeploymentPlan()
 
     for file_path in sorted(mods_dir.rglob("*")):
@@ -217,6 +220,11 @@ def classify_files(mods_dir: Path, game_domain: str) -> DeploymentPlan:
         # Skip hidden/tool files at root
         if parts[0].startswith("."):
             plan.skipped.append((rel, "hidden file"))
+            continue
+
+        # Skip unselected FOMOD option folders
+        if parts[0] in fomod_skip:
+            plan.skipped.append((rel, "unselected FOMOD option"))
             continue
 
         # Strip wrapper directories (numbered options, SFSE version dirs)

--- a/nexus_collection_dl/fomod.py
+++ b/nexus_collection_dl/fomod.py
@@ -1,0 +1,229 @@
+"""FOMOD option folder resolution - filter unselected mod options during deploy."""
+
+import re
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+def parse_module_config(config_path: Path) -> dict[str, str]:
+    """
+    Parse a ModuleConfig.xml to map option names to their source folders.
+
+    Returns dict of {option_name_lower: source_folder_name}.
+    Handles UTF-16 encoded files (common in FOMOD configs).
+    """
+    try:
+        # Try UTF-8 first, then UTF-16
+        try:
+            tree = ET.parse(config_path)
+        except ET.ParseError:
+            with open(config_path, "r", encoding="utf-16") as f:
+                content = f.read()
+            tree = ET.ElementTree(ET.fromstring(content))
+    except Exception:
+        return {}
+
+    root = tree.getroot()
+    # Strip namespace if present
+    ns = ""
+    if root.tag.startswith("{"):
+        ns = root.tag.split("}")[0] + "}"
+
+    option_to_folder: dict[str, str] = {}
+
+    # Find all plugin entries (install options)
+    for plugin in root.iter(f"{ns}plugin") if ns else root.iter("plugin"):
+        name = plugin.get("name", "")
+        if not name:
+            continue
+
+        # Look for files/folders in this plugin's install section
+        for files_elem in plugin.iter(f"{ns}files") if ns else plugin.iter("files"):
+            for folder in files_elem.iter(f"{ns}folder") if ns else files_elem.iter("folder"):
+                source = folder.get("source", "")
+                if source:
+                    option_to_folder[name.lower()] = source
+                    break
+            for file_elem in files_elem.iter(f"{ns}file") if ns else files_elem.iter("file"):
+                source = file_elem.get("source", "")
+                if source:
+                    # Use the top-level folder from the source path
+                    top_folder = source.split("/")[0].split("\\")[0]
+                    if top_folder:
+                        option_to_folder[name.lower()] = top_folder
+                    break
+
+    return option_to_folder
+
+
+def _get_required_folders(config_path: Path) -> set[str]:
+    """Extract requiredInstallFiles folders from ModuleConfig.xml."""
+    try:
+        try:
+            tree = ET.parse(config_path)
+        except ET.ParseError:
+            with open(config_path, "r", encoding="utf-16") as f:
+                content = f.read()
+            tree = ET.ElementTree(ET.fromstring(content))
+    except Exception:
+        return set()
+
+    root = tree.getroot()
+    ns = ""
+    if root.tag.startswith("{"):
+        ns = root.tag.split("}")[0] + "}"
+
+    required: set[str] = set()
+    for req in root.iter(f"{ns}requiredInstallFiles") if ns else root.iter("requiredInstallFiles"):
+        for folder in req.iter(f"{ns}folder") if ns else req.iter("folder"):
+            source = folder.get("source", "")
+            if source:
+                top = source.split("/")[0].split("\\")[0]
+                if top:
+                    required.add(top.lower())
+        for file_elem in req.iter(f"{ns}file") if ns else req.iter("file"):
+            source = file_elem.get("source", "")
+            if source:
+                top = source.split("/")[0].split("\\")[0]
+                if top:
+                    required.add(top.lower())
+
+    return required
+
+
+def resolve_selected_folders(choices: dict, option_to_folder: dict[str, str]) -> set[str]:
+    """
+    Cross-reference manifest choices with ModuleConfig option-to-folder mapping.
+
+    Returns set of SELECTED folder names (lowercase).
+    """
+    selected: set[str] = set()
+
+    # choices structure from collection.json:
+    # {"steps": [{"stepId": N, "selectedOptions": [{"groupId": N, "optionId": N, "optionName": "..."}]}]}
+    steps = choices.get("steps", [])
+    for step in steps:
+        for option in step.get("selectedOptions", []):
+            option_name = option.get("optionName", "").lower()
+            if option_name in option_to_folder:
+                folder = option_to_folder[option_name]
+                selected.add(folder.lower())
+
+    return selected
+
+
+# Pattern for numbered option folders
+_NUMBERED_PREFIX_RE = re.compile(r"^\d{2,3}\s*[-_]\s*(.+)$")
+
+
+def _fuzzy_match_folder_to_choice(folder_name: str, choice_names: set[str]) -> bool:
+    """Check if a folder name (with number prefix stripped) matches any choice name."""
+    # Strip numbered prefix: "01 - Bright Bullet Tracers" -> "Bright Bullet Tracers"
+    m = _NUMBERED_PREFIX_RE.match(folder_name)
+    if m:
+        stripped = m.group(1).strip().lower()
+    else:
+        stripped = folder_name.strip().lower()
+
+    # Exact match
+    if stripped in choice_names:
+        return True
+
+    # Partial match - folder name contained in a choice or vice versa
+    for choice in choice_names:
+        if stripped in choice or choice in stripped:
+            return True
+
+    return False
+
+
+def build_fomod_skip_set(mods_dir: Path, mod_choices: dict[int, dict]) -> set[str]:
+    """
+    Build set of folder names to SKIP during deployment (unselected FOMOD options).
+
+    Strategy:
+    1. For mods with ModuleConfig.xml on disk: parse it, cross-reference with choices
+    2. For mods with choices but no ModuleConfig.xml: use name matching on numbered folders
+
+    Returns set of folder names (original case from disk) to skip.
+    """
+    skip_set: set[str] = set()
+
+    if not mod_choices:
+        return skip_set
+
+    # Collect all choice option names for name-matching fallback
+    all_choice_names: dict[int, set[str]] = {}
+    all_selected_names: dict[int, set[str]] = {}
+    for mod_id, choices in mod_choices.items():
+        selected_names: set[str] = set()
+        all_names: set[str] = set()
+        for step in choices.get("steps", []):
+            for option in step.get("selectedOptions", []):
+                name = option.get("optionName", "").lower()
+                if name:
+                    selected_names.add(name)
+                    all_names.add(name)
+            # Also collect UNselected options if available
+            # The manifest only has selectedOptions, so all_names == selected_names
+            # We'll use folder enumeration to find unselected ones
+        all_selected_names[mod_id] = selected_names
+        all_choice_names[mod_id] = all_names
+
+    # Strategy 1: Find ModuleConfig.xml files at root of mods_dir
+    config_handled_mods: set[int] = set()
+    for config_path in mods_dir.glob("**/ModuleConfig.xml"):
+        # Only process configs at reasonable depth (not deeply nested)
+        rel = config_path.relative_to(mods_dir)
+        if len(rel.parts) > 3:
+            continue
+
+        option_to_folder = parse_module_config(config_path)
+        if not option_to_folder:
+            continue
+
+        required_folders = _get_required_folders(config_path)
+
+        # Try to match this config to a mod with choices
+        for mod_id, choices in mod_choices.items():
+            if mod_id in config_handled_mods:
+                continue
+
+            selected = resolve_selected_folders(choices, option_to_folder)
+            if not selected:
+                continue
+
+            config_handled_mods.add(mod_id)
+
+            # All folders mentioned in the config that are NOT selected and NOT required
+            all_config_folders = {f.lower() for f in option_to_folder.values()}
+            unselected = all_config_folders - selected - required_folders
+
+            # Find actual folder names on disk that match unselected folders
+            for item in mods_dir.iterdir():
+                if item.is_dir() and item.name.lower() in unselected:
+                    skip_set.add(item.name)
+
+    # Strategy 2: Name matching for mods with choices but no ModuleConfig.xml
+    # Look at numbered folders on disk and match against choice names
+    numbered_folders = []
+    for item in mods_dir.iterdir():
+        if item.is_dir() and _NUMBERED_PREFIX_RE.match(item.name):
+            numbered_folders.append(item.name)
+
+    if numbered_folders:
+        for mod_id, choices in mod_choices.items():
+            if mod_id in config_handled_mods:
+                continue
+
+            selected_names = all_selected_names.get(mod_id, set())
+            if not selected_names:
+                continue
+
+            # For each numbered folder, check if it matches a selected option
+            for folder_name in numbered_folders:
+                if not _fuzzy_match_folder_to_choice(folder_name, selected_names):
+                    # This folder doesn't match any selected option - skip it
+                    skip_set.add(folder_name)
+
+    return skip_set

--- a/nexus_collection_dl/manifest.py
+++ b/nexus_collection_dl/manifest.py
@@ -25,6 +25,7 @@ class CollectionManifest:
         plugin_rules: list[dict[str, Any]],
         mod_phases: dict[int, int],  # mod_id -> phase
         logical_name_to_mod_id: dict[str, int] | None = None,
+        mod_choices: dict[int, dict] | None = None,
     ):
         self.mod_rules = mod_rules
         self.plugins = plugins
@@ -32,6 +33,7 @@ class CollectionManifest:
         self.mod_phases = mod_phases
         # Maps logicalFilename -> modId for resolving mod rules
         self.logical_name_to_mod_id = logical_name_to_mod_id or {}
+        self.mod_choices = mod_choices or {}
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize for state storage."""
@@ -41,6 +43,7 @@ class CollectionManifest:
             "plugin_rules": self.plugin_rules,
             "mod_phases": {str(k): v for k, v in self.mod_phases.items()},
             "logical_name_to_mod_id": self.logical_name_to_mod_id,
+            "mod_choices": {str(k): v for k, v in self.mod_choices.items()},
         }
 
     @classmethod
@@ -55,6 +58,7 @@ class CollectionManifest:
                 k: int(v)
                 for k, v in data.get("logical_name_to_mod_id", {}).items()
             },
+            mod_choices={int(k): v for k, v in data.get("mod_choices", {}).items()},
         )
 
 
@@ -152,6 +156,7 @@ def _parse_collection_json(data: dict[str, Any]) -> CollectionManifest:
     # Build mod_id -> phase mapping and logicalFilename -> modId lookup
     mod_phases: dict[int, int] = {}
     logical_name_to_mod_id: dict[str, int] = {}
+    mod_choices: dict[int, dict] = {}
     for mod_entry in data.get("mods", []):
         source = mod_entry.get("source", {})
         mod_id = source.get("modId")
@@ -162,6 +167,10 @@ def _parse_collection_json(data: dict[str, Any]) -> CollectionManifest:
             logical = source.get("logicalFilename", "")
             if logical:
                 logical_name_to_mod_id[logical] = int(mod_id)
+
+        choices = mod_entry.get("choices")
+        if choices and mod_id is not None:
+            mod_choices[int(mod_id)] = choices
 
     # Plugin load order: prefer "loadOrder" (has actual ESM/ESP entries with
     # enabled status) over "plugins" (often empty)
@@ -186,4 +195,5 @@ def _parse_collection_json(data: dict[str, Any]) -> CollectionManifest:
         plugin_rules=plugin_rules,
         mod_phases=mod_phases,
         logical_name_to_mod_id=logical_name_to_mod_id,
+        mod_choices=mod_choices,
     )

--- a/nexus_collection_dl/service.py
+++ b/nexus_collection_dl/service.py
@@ -768,7 +768,12 @@ class ModManagerService:
 
         # Classify files
         progress("classify", 0.2, "Classifying files...")
-        plan = classify_files(mods_dir, game_domain)
+        # Load manifest choices for FOMOD filtering
+        manifest_choices = {}
+        if state.manifest_data:
+            manifest = CollectionManifest.from_dict(state.manifest_data)
+            manifest_choices = manifest.mod_choices
+        plan = classify_files(mods_dir, game_domain, mod_choices=manifest_choices)
 
         if plan.total_files == 0:
             return DeployResult(0, [], [], str(game_dir), False, skipped=len(plan.skipped))


### PR DESCRIPTION
## Summary
- Parse FOMOD `choices` from collection.json manifest per mod
- New `fomod.py` module: parse ModuleConfig.xml, resolve selected folders, fuzzy-match numbered folders by name
- Filter unselected option folders in `classify_files` before deployment
- Thread `mod_choices` through service.py deploy and cli.py dry-run paths
- Builds a **skip set** (exclude list) rather than allow list for safety

This should dramatically reduce the ~454 false conflicts seen when deploying FOMOD-heavy collections like Starfield, since only the author-selected options will be deployed instead of all variants.

## Test plan
- [ ] Deploy Starfield collection - verify conflict count drops from 454
- [ ] Verify FOMOD mods deploy only selected options (e.g. Weapons of Fate: Bright Bullet Tracers + Realistic Bullet Speed)
- [ ] Verify non-FOMOD numbered folders still deploy correctly
- [ ] Test dry-run path also filters correctly

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)