### PR TITLE
feat: tool version check + auto-update

### DIFF
--- a/nexus_collection_dl/__init__.py
+++ b/nexus_collection_dl/__init__.py
@@ -1,3 +1,3 @@
 """Nexus Collection Downloader - Download mod collections from Nexus Mods."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/nexus_collection_dl/cli.py
+++ b/nexus_collection_dl/cli.py
@@ -27,13 +27,23 @@ console = Console()
     hidden=True,
     help="Force free-user mode (for testing)",
 )
+@click.option(
+    "--skip-update-check",
+    is_flag=True,
+    hidden=True,
+    help="Skip automatic version check",
+)
 @click.pass_context
-def main(ctx: click.Context, api_key: str | None, free: bool) -> None:
+def main(ctx: click.Context, api_key: str | None, free: bool, skip_update_check: bool) -> None:
     """Download mod collections from Nexus Mods."""
     ctx.ensure_object(dict)
     ctx.obj["api_key"] = api_key
     ctx.obj["force_free"] = free
     ctx.obj["service"] = ModManagerService(api_key, force_free=free)
+
+    if not skip_update_check:
+        from .updater import check_and_prompt_update
+        check_and_prompt_update(console)
 
 
 def _cli_progress(event: str, pct: float, msg: str) -> None:

--- a/nexus_collection_dl/updater.py
+++ b/nexus_collection_dl/updater.py
@@ -1,0 +1,151 @@
+"""Auto-update checker for nexus-collection-dl (git clone installs)."""
+
+import json
+import subprocess
+import time
+from pathlib import Path
+
+import click
+
+
+CACHE_DIR = Path.home() / ".cache" / "nexus-dl"
+CACHE_FILE = CACHE_DIR / "version-check.json"
+CACHE_TTL = 3600  # 1 hour
+GITHUB_REPO = "scottmccarrison/nexus-collection-dl"
+
+
+def get_current_version() -> str:
+    """Get the currently installed version via importlib.metadata."""
+    import importlib.metadata
+
+    return importlib.metadata.version("nexus-collection-dl")
+
+
+def _read_cache() -> dict | None:
+    """Read cached version check result if still fresh."""
+    try:
+        data = json.loads(CACHE_FILE.read_text())
+        if time.time() - data["last_check"] < CACHE_TTL:
+            return data
+    except (FileNotFoundError, KeyError, json.JSONDecodeError, OSError):
+        pass
+    return None
+
+
+def _write_cache(latest: str) -> None:
+    """Write version check result to cache."""
+    try:
+        CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        CACHE_FILE.write_text(json.dumps({
+            "last_check": time.time(),
+            "latest": latest,
+        }))
+    except OSError:
+        pass
+
+
+def get_latest_release() -> tuple[str, str] | None:
+    """Fetch latest release from GitHub API.
+
+    Returns (version, html_url) or None on any error.
+    """
+    import requests
+
+    try:
+        resp = requests.get(
+            f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest",
+            timeout=3,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        tag = data["tag_name"].lstrip("v")
+        return (tag, data["html_url"])
+    except Exception:
+        return None
+
+
+def check_for_update() -> tuple[str, str, str] | None:
+    """Check if a newer version is available.
+
+    Returns (current, latest, release_url) if update available, else None.
+    Uses a 1-hour cache to avoid hammering GitHub.
+    """
+    from packaging.version import parse
+
+    current = get_current_version()
+
+    # Check cache first
+    cached = _read_cache()
+    if cached:
+        latest = cached["latest"]
+        if parse(latest) > parse(current):
+            url = f"https://github.com/{GITHUB_REPO}/releases/tag/v{latest}"
+            return (current, latest, url)
+        return None
+
+    # Fetch from GitHub
+    result = get_latest_release()
+    if result is None:
+        return None
+
+    latest, release_url = result
+    _write_cache(latest)
+
+    if parse(latest) > parse(current):
+        return (current, latest, release_url)
+    return None
+
+
+def do_update() -> bool:
+    """Pull latest code and reinstall via pip.
+
+    Returns True on success, False on failure.
+    """
+    import importlib.metadata
+
+    try:
+        dist = importlib.metadata.distribution("nexus-collection-dl")
+        src_dir = Path(dist.locate_file(""))
+    except Exception:
+        return False
+
+    try:
+        subprocess.run(
+            ["git", "-C", str(src_dir), "pull", "--ff-only"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["pip", "install", "-e", str(src_dir)],
+            check=True,
+            capture_output=True,
+        )
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def check_and_prompt_update(console) -> None:
+    """Check for updates and prompt the user to install.
+
+    Called from CLI on every invocation (unless --skip-update-check).
+    Silently returns on any error - never blocks the user.
+    """
+    try:
+        result = check_for_update()
+    except Exception:
+        return
+
+    if result is None:
+        return
+
+    current, latest, release_url = result
+    console.print(f"[yellow]Update available:[/yellow] v{current} -> v{latest}")
+    console.print(f"[dim]{release_url}[/dim]")
+
+    if click.confirm("Update now?", default=True):
+        console.print("[dim]Updating...[/dim]")
+        if do_update():
+            console.print("[green]Updated successfully![/green] Restart to use the new version.")
+        else:
+            console.print("[red]Update failed.[/red] Try manually: git pull && pip install -e .")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "py7zr>=0.20.0",
     "rarfile>=4.0",
     "flask>=3.0.0",
+    "packaging>=21.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- New `updater.py` module: checks GitHub releases for newer versions on every CLI invocation
- 1-hour cache (`~/.cache/nexus-dl/version-check.json`) to avoid rate-limiting
- Prompts user to update via `git pull --ff-only` + `pip install -e .`
- Hidden `--skip-update-check` flag to bypass
- Syncs `__init__.py` version from 0.1.0 to 0.2.0
- Adds `packaging` dependency for version comparison

## Test plan
- [x] `python3 -c "from nexus_collection_dl.updater import get_current_version; print(get_current_version())"` returns 0.2.0
- [x] `check_for_update()` returns None when no GitHub release exists (no crash)
- [x] `nexus-dl --skip-update-check --help` works without version check
- [ ] After creating a GitHub release, verify update prompt appears

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)