### PR TITLE
feat: per-collection subdirectories in sync

### DIFF
--- a/nexus_collection_dl/cli.py
+++ b/nexus_collection_dl/cli.py
@@ -8,7 +8,7 @@ from rich.console import Console
 from rich.table import Table
 
 from .api import NexusAPIError
-from .collection import CollectionParseError, ModParseError
+from .collection import CollectionParseError, ModParseError, parse_collection_url
 from .service import ModManagerService, PendingDownload, _select_mod_file
 from .state import StateError
 
@@ -108,6 +108,9 @@ def sync(
     except (NexusAPIError, CollectionParseError, StateError) as e:
         console.print(f"[red]Error:[/red] {e}")
         sys.exit(1)
+
+    resolved_dir = mods_dir / parse_collection_url(collection_url).slug
+    console.print(f"[dim]Collection directory: {resolved_dir}[/dim]")
 
     if result.errors:
         for err in result.errors:

--- a/nexus_collection_dl/service.py
+++ b/nexus_collection_dl/service.py
@@ -307,6 +307,8 @@ class ModManagerService:
 
         # Parse URL
         collection_info = parse_collection_url(collection_url)
+        mods_dir = mods_dir / collection_info.slug
+        mods_dir.mkdir(parents=True, exist_ok=True)
 
         # Check premium status
         progress("init", 0.0, "Validating API key...")


### PR DESCRIPTION
## Summary
- Resolves `mods_dir` to a subdirectory named after the collection slug at the start of `sync()`, isolating state files and downloads per collection
- Displays the resolved collection directory path in CLI output after sync
- No changes needed for `update()` - users already point at the collection subdir

Closes #36

## Test plan
- [ ] Sync two different collections to the same `--mods-dir` and verify each gets its own subdirectory
- [ ] Verify `.nexus-state.json` lives inside each collection subdirectory
- [ ] Verify `update` still works when pointed at a collection subdirectory

🤖 Generated with [Claude Code](https://claude.com/claude-code)