### PR TITLE
fix: save state after each mod for abort resilience

### DIFF
--- a/nexus_collection_dl/service.py
+++ b/nexus_collection_dl/service.py
@@ -432,12 +432,11 @@ class ModManagerService:
                     file_path.unlink()
                     extracted += 1
                 state.add_mod(mod_info)
+                state.save()
                 pct = 0.75 + 0.15 * ((i + 1) / len(results))
                 progress("extract", pct, f"Extracted {mod_info['mod_name']}")
             except ExtractionError as e:
                 errors.append(f"Extraction error for {mod_info['mod_name']}: {e}")
-
-        state.save()
 
         # Generate load order
         if not no_load_order:


### PR DESCRIPTION
## Summary
- Moves `state.save()` inside the per-mod extract loop so each completed mod is persisted to `.nexus-state.json` immediately
- An aborted sync now preserves all progress - only the interrupted mod and remaining ones retry on re-run
- Removes the redundant end-of-loop `state.save()` since each iteration already saves

Closes #38

## Test plan
- [ ] Sync a collection, verify state file updates after each mod (watch file timestamps)
- [ ] Abort mid-sync (Ctrl+C), re-run sync, confirm completed mods are skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)