### PR TITLE
feat: tool version check on every CLI command

### DIFF
--- a/nexus_collection_dl/__init__.py
+++ b/nexus_collection_dl/__init__.py
@@ -1,3 +1,3 @@
 """Nexus Collection Downloader - Download mod collections from Nexus Mods."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/nexus_collection_dl/cli.py
+++ b/nexus_collection_dl/cli.py
@@ -11,6 +11,8 @@ from .api import NexusAPIError
 from .collection import CollectionParseError, ModParseError, parse_collection_url
 from .service import ModManagerService, PendingDownload, _select_mod_file
 from .state import StateError
+from .version_check import check_for_update
+from . import __version__
 
 console = Console()
 
@@ -30,6 +32,12 @@ console = Console()
 @click.pass_context
 def main(ctx: click.Context, api_key: str | None, free: bool) -> None:
     """Download mod collections from Nexus Mods."""
+    update_msg = check_for_update()
+    if update_msg:
+        console.print(f"[yellow]{update_msg}[/yellow]")
+    else:
+        console.print(f"[dim]nexus-dl v{__version__}[/dim]")
+
     ctx.ensure_object(dict)
     ctx.obj["api_key"] = api_key
     ctx.obj["force_free"] = free

--- a/nexus_collection_dl/version_check.py
+++ b/nexus_collection_dl/version_check.py
@@ -1,0 +1,36 @@
+"""Check for newer releases on GitHub."""
+
+import urllib.request
+import json
+
+from . import __version__
+
+GITHUB_REPO = "scottmccarrison/nexus-collection-dl"
+TIMEOUT_SECONDS = 2
+
+
+def _parse_version(v: str) -> tuple[int, ...]:
+    """Parse a version string like '0.2.0' into a comparable tuple."""
+    return tuple(int(x) for x in v.split("."))
+
+
+def check_for_update() -> str | None:
+    """Return a message if a newer version is available, or None.
+
+    Returns None silently on any failure (offline, timeout, no releases).
+    """
+    try:
+        url = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
+        req = urllib.request.Request(url, headers={"Accept": "application/vnd.github+json"})
+        with urllib.request.urlopen(req, timeout=TIMEOUT_SECONDS) as resp:
+            data = json.loads(resp.read())
+        tag = data.get("tag_name", "")
+        latest = tag.lstrip("v")
+        if _parse_version(latest) > _parse_version(__version__):
+            return (
+                f"nexus-dl v{__version__} - update available (v{latest}). "
+                f"Run: pip install --upgrade nexus-collection-dl"
+            )
+    except Exception:
+        return None
+    return None


### PR DESCRIPTION
## Summary
- Prints `nexus-dl v0.2.0` on every CLI command
- If a newer GitHub release exists, shows yellow update warning with install command
- Non-blocking with 2s timeout - silently skipped if offline or no releases
- Fixes `__init__.py` version (was stuck at 0.1.0)

Closes #40

## Test plan
- [x] `nexus-dl sync --help` shows version banner
- [x] No releases exist yet - falls through to "v0.2.0" display
- [x] Import check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)