### PR TITLE
fix: use collection name for subdirectory instead of slug

### DIFF
--- a/nexus_collection_dl/cli.py
+++ b/nexus_collection_dl/cli.py
@@ -8,7 +8,7 @@ from rich.console import Console
 from rich.table import Table
 
 from .api import NexusAPIError
-from .collection import CollectionParseError, ModParseError, parse_collection_url
+from .collection import CollectionParseError, ModParseError
 from .service import ModManagerService, PendingDownload, _select_mod_file
 from .state import StateError
 from .version_check import check_for_update
@@ -117,8 +117,8 @@ def sync(
         console.print(f"[red]Error:[/red] {e}")
         sys.exit(1)
 
-    resolved_dir = mods_dir / parse_collection_url(collection_url).slug
-    console.print(f"[dim]Collection directory: {resolved_dir}[/dim]")
+    if result.collection_dir:
+        console.print(f"[dim]Collection directory: {result.collection_dir}[/dim]")
 
     if result.errors:
         for err in result.errors:

--- a/nexus_collection_dl/service.py
+++ b/nexus_collection_dl/service.py
@@ -1,6 +1,7 @@
 """Service layer - business logic extracted from CLI for programmatic use."""
 
 import os
+import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -34,6 +35,13 @@ from .steam import STEAM_APP_IDS, find_game_dir, find_proton_prefix
 
 # progress callback: (event_type, percentage 0-1, message)
 ProgressCallback = Callable[[str, float, str], None]
+
+
+def _sanitize_dirname(name: str) -> str:
+    """Turn a collection name into a safe directory name."""
+    name = re.sub(r'[<>:"/\\|?*]', "", name)
+    name = name.strip(". ")
+    return name or "collection"
 
 
 @dataclass
@@ -90,6 +98,7 @@ class SyncResult:
     tracked: int = 0
     untracked: int = 0
     pending_downloads: list[PendingDownload] = field(default_factory=list)
+    collection_dir: Path | None = None
 
 
 @dataclass
@@ -307,8 +316,6 @@ class ModManagerService:
 
         # Parse URL
         collection_info = parse_collection_url(collection_url)
-        mods_dir = mods_dir / collection_info.slug
-        mods_dir.mkdir(parents=True, exist_ok=True)
 
         # Check premium status
         progress("init", 0.0, "Validating API key...")
@@ -321,6 +328,11 @@ class ModManagerService:
             collection_info.game_domain, collection_info.slug
         )
 
+        # Resolve mods_dir to a per-collection subdirectory
+        dir_name = _sanitize_dirname(collection_data["name"])
+        mods_dir = mods_dir / dir_name
+        mods_dir.mkdir(parents=True, exist_ok=True)
+
         mods = collection_data["mods"]
         dupes = collection_data.get("duplicates_removed", 0)
         if dupes:
@@ -329,7 +341,7 @@ class ModManagerService:
             mods = [m for m in mods if not m.get("optional", False)]
 
         if not mods:
-            return SyncResult(0, 0, [], [])
+            return SyncResult(0, 0, [], [], collection_dir=mods_dir)
 
         # Initialize state
         state = CollectionState(mods_dir)
@@ -386,6 +398,7 @@ class ModManagerService:
                 errors=errors,
                 load_order_files=load_order_files,
                 pending_downloads=pending_downloads,
+                collection_dir=mods_dir,
             )
 
         # Premium user: download directly
@@ -456,6 +469,7 @@ class ModManagerService:
             load_order_files=load_order_files,
             tracked=tracked,
             untracked=untracked,
+            collection_dir=mods_dir,
         )
 
     def update(


### PR DESCRIPTION
## Summary
- Subdirectory now uses the collection's human-readable name (e.g. "Starfield Modding Essentials") instead of the opaque slug (e.g. "49slmk")
- Names are sanitized for filesystem safety (strips `<>:"/\|?*` and leading/trailing dots/spaces)
- Moved subdirectory creation after the API fetch since the name comes from the collection data
- Added `collection_dir` field to `SyncResult` so the CLI can display the resolved path without re-parsing

## Test plan
- [ ] Sync a collection, verify subdirectory is named after collection (not slug)
- [ ] Verify collection names with special characters are sanitized

🤖 Generated with [Claude Code](https://claude.com/claude-code)