### PR TITLE
Fix multi-file mod support, add BG3 deployment, fix extraction structure

### DIFF
--- a/nexus_collection_dl/api.py
+++ b/nexus_collection_dl/api.py
@@ -12,13 +12,11 @@ REST_BASE_URL = "https://api.nexusmods.com/v1"
 
 class NexusAPIError(Exception):
     """Base exception for Nexus API errors."""
-
     pass
 
 
 class NexusPremiumRequired(NexusAPIError):
     """Raised when Premium membership is required for an operation."""
-
     pass
 
 
@@ -88,12 +86,16 @@ class NexusAPI:
 
     def get_collection_mods(self, game_domain: str, slug: str) -> dict[str, Any]:
         """
-        Get collection metadata and mod list from the latest revision.
+        Get collection metadata and ALL mod files from the latest revision.
+
+        IMPORTANT: A collection can include multiple files from the same mod
+        (e.g. a core pak + texture pack + compatibility patch, all from mod_id 18726).
+        We return ALL files, keyed by file_id not mod_id, to avoid dropping any.
 
         Returns dict with:
             - name: collection name
             - revision: revision number
-            - mods: list of mod info dicts
+            - mods: list of mod file info dicts (one entry per FILE, not per mod)
         """
         query = """
         query GetCollection($slug: String!) {
@@ -154,11 +156,22 @@ class NexusAPI:
         mod_files = revision.get("modFiles", [])
 
         mods = []
+        seen_file_ids: set[int] = set()
+
         for mf in mod_files:
             file_info = mf.get("file", {})
             mod_info = file_info.get("mod", {})
             if not file_info or not mod_info:
                 continue
+
+            file_id = file_info.get("fileId")
+            if file_id is None:
+                continue
+
+            # Skip truly duplicate file_ids (shouldn't happen but be safe)
+            if file_id in seen_file_ids:
+                continue
+            seen_file_ids.add(file_id)
 
             # Extract mod requirements
             req_nodes = (
@@ -172,7 +185,7 @@ class NexusAPI:
                 {
                     "mod_id": mod_info.get("modId"),
                     "mod_name": mod_info.get("name"),
-                    "file_id": file_info.get("fileId"),
+                    "file_id": file_id,
                     "filename": file_info.get("name"),
                     "version": file_info.get("version"),
                     "size_bytes": file_info.get("sizeInBytes"),
@@ -181,22 +194,11 @@ class NexusAPI:
                 }
             )
 
-        # Deduplicate by mod_id, keeping the last occurrence so the
-        # collection's intended load order wins when the same mod appears
-        # multiple times (patches, updates, revised entries).
-        seen: dict[int, int] = {}
-        for i, mod in enumerate(mods):
-            seen[mod["mod_id"]] = i
-        unique_indices = set(seen.values())
-        dupes_removed = len(mods) - len(unique_indices)
-        mods = [m for i, m in enumerate(mods) if i in unique_indices]
-
         return {
             "id": collection.get("id"),
             "slug": collection.get("slug"),
             "name": collection.get("name"),
             "summary": collection.get("summary"),
-            "duplicates_removed": dupes_removed,
             "game_domain": actual_game,
             "revision": revision.get("revisionNumber"),
             "download_link": download_link,
@@ -214,7 +216,6 @@ class NexusAPI:
         response = self.session.get(url)
         data = self._handle_response(response)
 
-        # Response is a list of CDN options, pick the first one
         if not data or not isinstance(data, list):
             raise NexusAPIError(f"Unexpected download link response: {data}")
 

--- a/nexus_collection_dl/deploy.py
+++ b/nexus_collection_dl/deploy.py
@@ -9,7 +9,29 @@ from pathlib import Path
 # Bethesda plugin/archive extensions
 BETHESDA_EXTENSIONS = {".esm", ".esp", ".esl", ".ba2"}
 
-# Known asset directories that belong under Data/
+# BG3 pak file extension
+BG3_PAK_EXTENSION = ".pak"
+
+# BG3 virtual texture extensions (go to Data/ directly, not in pak)
+BG3_VIRTUAL_TEXTURE_EXTENSIONS = {".gts", ".gtp"}
+
+# BG3 loose file extensions that go into Data/ structure
+BG3_LOOSE_EXTENSIONS = {
+    ".dds", ".DDS",  # textures
+    ".gr2", ".GR2",  # Granny2 animations/models
+    ".lsf", ".lsx",  # Larian save formats
+    ".cur",          # cursors
+    ".ttf", ".otf",  # fonts
+    ".xaml",         # UI
+}
+
+# BG3 native mod paths - go to game bin/ not Data/
+BG3_NATIVE_MOD_PATHS = {
+    "bin",
+    "nativemods",
+}
+
+# Known asset directories that belong under Data/ (Bethesda)
 ASSET_DIRS = {
     "geometries",
     "textures",
@@ -42,11 +64,13 @@ SKIP_PATTERNS = {
     "load-order.txt",
     "plugins.txt",
     "__folder_managed_by_vortex",
+    "__macosx",
 }
 
-SKIP_EXTENSIONS = {".txt", ".md", ".jpg", ".jpeg", ".png", ".gif", ".pdf", ".log"}
+SKIP_EXTENSIONS = {".txt", ".md", ".jpg", ".jpeg", ".png", ".gif", ".pdf", ".log",
+                   ".url", ".lnk", ".json"}
 
-# Starfield INI settings for mod support
+# Starfield/Skyrim/Fallout INI settings for mod support
 GAME_INI_SETTINGS = {
     "starfield": {
         "filename": "StarfieldCustom.ini",
@@ -137,35 +161,101 @@ class DeployResult:
     errors: list[str] = field(default_factory=list)
 
 
+def _is_bg3_game(game_domain: str) -> bool:
+    """Check if this is a Baldur's Gate 3 deployment."""
+    return game_domain.lower() in ("baldursgate3", "baldurs_gate_3", "bg3")
+
+
 def classify_file(rel_path: Path, game_domain: str) -> tuple[str, Path] | None:
     """
     Classify a single file and return (target_base, relative_dest) or None to skip.
 
-    target_base is "root" for game root or "data" for Data/ directory.
+    target_base values:
+        "root"    - game installation root (e.g. bin/)
+        "data"    - game Data/ directory
+        "staging" - stays in mod staging dir (e.g. .pak files for BG3)
+
+    For BG3:
+        .pak files stay in the staging/collection directory and are symlinked to Data/
+        bin/ and NativeMods/ go to the game's bin/ directory
+        Loose files (DDS, GR2, etc.) with a Data/ prefix go to game Data/
+        Virtual textures (.gts, .gtp) go to game Data/
     """
     parts = rel_path.parts
     name = rel_path.name
     name_lower = name.lower()
     suffix_lower = rel_path.suffix.lower()
+    lower_parts = [p.lower() for p in parts]
 
-    # Skip metadata/docs
-    if name_lower in SKIP_PATTERNS or name_lower.startswith("readme"):
+    # Skip metadata/docs/junk
+    if name_lower in {p.lower() for p in SKIP_PATTERNS}:
+        return None
+    if name_lower.startswith("readme"):
         return None
     if suffix_lower in SKIP_EXTENSIONS and suffix_lower not in BETHESDA_EXTENSIONS:
         return None
     if any(p.lower() in SKIP_PATTERNS for p in parts):
         return None
+    # Skip Mac OS metadata folders
+    if "__macosx" in lower_parts:
+        return None
 
-    # SFSE root files (sfse_loader.exe, sfse_*.dll) - deploy to game root
+    # ── BG3-specific handling ──────────────────────────────────────────────────
+    if _is_bg3_game(game_domain):
+        # .pak files stay in the staging directory.
+        # nexus-dl's deploy step symlinks all .pak files from staging → Data/
+        if suffix_lower == ".pak":
+            return ("staging", Path(name))
+
+        # bin/ and NativeMods/ → game root bin/
+        if lower_parts[0] in BG3_NATIVE_MOD_PATHS:
+            return ("root", Path("bin") / Path(*parts[1:]))
+
+        # Explicit Data/ prefix → strip it and deploy to game Data/
+        if lower_parts[0] == "data" and len(parts) > 1:
+            remainder = Path(*parts[1:])
+            return ("data", remainder)
+
+        # Generated/ prefix → deploy to game Data/Generated/
+        if lower_parts[0] == "generated" and len(parts) > 1:
+            return ("data", rel_path)
+
+        # Virtual textures → Data/ root
+        if suffix_lower in BG3_VIRTUAL_TEXTURE_EXTENSIONS:
+            return ("data", Path(name))
+
+        # Loose DDS/GR2/etc at root level → Data/ root
+        if len(parts) == 1 and suffix_lower.lower() in {e.lower() for e in BG3_LOOSE_EXTENSIONS}:
+            return ("data", Path(name))
+
+        # Subfolder containing Data/ structure (e.g. "ModName/Data/Public/...")
+        if "data" in lower_parts:
+            data_idx = lower_parts.index("data")
+            if data_idx < len(parts) - 1:
+                remainder = Path(*parts[data_idx + 1:])
+                return ("data", remainder)
+
+        # DLL files at root → game bin/ (native mods)
+        if len(parts) == 1 and suffix_lower == ".dll":
+            return ("root", Path("bin") / "NativeMods" / name)
+
+        # TOML/INI configs for native mods at root → game bin/NativeMods/
+        if len(parts) == 1 and suffix_lower in (".toml", ".ini"):
+            return ("root", Path("bin") / "NativeMods" / name)
+
+        # Everything else for BG3 → skip (loose files without clear destination)
+        return None
+
+    # ── Non-BG3 (Bethesda) handling ───────────────────────────────────────────
+
+    # SFSE root files
     if name_lower.startswith("sfse_") and suffix_lower in (".exe", ".dll"):
         return ("root", Path(name))
 
     # Handle SFSE/Plugins/ at various depths
-    lower_parts = [p.lower() for p in parts]
     if "sfse" in lower_parts:
         sfse_idx = lower_parts.index("sfse")
         remainder = Path(*parts[sfse_idx:])
-        # Strip leading "data/" if present
         if lower_parts[0] == "data" and sfse_idx == 1:
             return ("data", remainder)
         elif sfse_idx == 0:
@@ -184,26 +274,27 @@ def classify_file(rel_path: Path, game_domain: str) -> tuple[str, Path] | None:
     if lower_parts[0] in ASSET_DIRS:
         return ("data", rel_path)
 
-    # Any other file - try to deploy under Data/
-    # This catches things like Meshes/, Textures/ nested inside subdirs
+    # Asset dirs nested inside subdirs
     for i, part_lower in enumerate(lower_parts):
         if part_lower in ASSET_DIRS:
             return ("data", Path(*parts[i:]))
 
-    # If it's a DLL at root, might be an SFSE plugin or ASI loader
+    # DLL at root → game root
     if len(parts) == 1 and suffix_lower == ".dll":
         return ("root", Path(name))
 
-    # INI files at root - could be game config
+    # INI files at root
     if len(parts) == 1 and suffix_lower == ".ini":
         return ("root", Path(name))
 
-    # Unknown file - deploy under Data/ as fallback for anything with
-    # a game-relevant extension, skip otherwise
     return ("data", rel_path)
 
 
-def classify_files(mods_dir: Path, game_domain: str, mod_choices: dict[int, dict] | None = None) -> DeploymentPlan:
+def classify_files(
+    mods_dir: Path,
+    game_domain: str,
+    mod_choices: dict[int, dict] | None = None,
+) -> DeploymentPlan:
     """Walk the staging directory and classify all files for deployment."""
     from .fomod import build_fomod_skip_set
     fomod_skip = build_fomod_skip_set(mods_dir, mod_choices or {})
@@ -243,11 +334,15 @@ def classify_files(mods_dir: Path, game_domain: str, mod_choices: dict[int, dict
         result = classify_file(effective_rel, game_domain)
 
         if result is None:
-            plan.skipped.append((rel, "metadata/docs"))
+            plan.skipped.append((rel, "skipped"))
             continue
 
         target_base, dest_rel = result
-        if target_base == "root":
+
+        if target_base == "staging":
+            # For BG3 paks: they stay in place, deploy will symlink them to Data/
+            plan.data_files.append((file_path, dest_rel))
+        elif target_base == "root":
             plan.game_root_files.append((file_path, dest_rel))
         else:
             plan.data_files.append((file_path, dest_rel))
@@ -281,7 +376,7 @@ def deploy(
     result = DeployResult()
     data_dir = game_dir / "Data"
 
-    # Deploy game root files (SFSE, root DLLs)
+    # Deploy game root files (native mods, SFSE, root DLLs)
     for src, dest_rel in plan.game_root_files:
         dest = game_dir / dest_rel
         if dry_run:
@@ -293,12 +388,11 @@ def deploy(
         except OSError as e:
             result.errors.append(f"{dest_rel}: {e}")
 
-    # Deploy Data/ files
+    # Deploy Data/ files (includes BG3 .pak symlinks)
     seen_dests: dict[Path, Path] = {}
     for src, dest_rel in plan.data_files:
         dest = data_dir / dest_rel
 
-        # Track conflicts (multiple sources -> same dest)
         if dest in seen_dests:
             result.conflicts.append(
                 f"{dest_rel}: overwritten by {src.name} (was {seen_dests[dest].name})"
@@ -326,7 +420,6 @@ def undeploy(deployed_files: list[dict]) -> int:
             try:
                 dest.unlink()
                 removed += 1
-                # Clean up empty parent dirs up to Data/ or game root
                 _cleanup_empty_parents(dest.parent)
             except OSError:
                 pass
@@ -363,12 +456,10 @@ def write_game_ini(ini_path: Path, game_domain: str) -> bool:
 
     ini_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Read existing content if present
     existing_lines = []
     if ini_path.exists():
         existing_lines = ini_path.read_text().splitlines()
 
-    # Parse existing sections
     existing_sections: dict[str, dict[str, str]] = {}
     current_section = ""
     for line in existing_lines:
@@ -380,13 +471,11 @@ def write_game_ini(ini_path: Path, game_domain: str) -> bool:
             key, _, value = stripped.partition("=")
             existing_sections[current_section][key.strip()] = value.strip()
 
-    # Merge our required settings
     for section, keys in settings["sections"].items():
         existing_sections.setdefault(section, {})
         for key, value in keys.items():
             existing_sections[section][key] = value
 
-    # Write back
     lines = []
     for section, keys in existing_sections.items():
         lines.append(f"[{section}]")

--- a/nexus_collection_dl/extractor.py
+++ b/nexus_collection_dl/extractor.py
@@ -11,7 +11,6 @@ import rarfile
 
 class ExtractionError(Exception):
     """Raised when archive extraction fails."""
-
     pass
 
 
@@ -21,18 +20,15 @@ def detect_archive_type(filepath: Path) -> str | None:
 
     Returns: 'zip', '7z', 'rar', or None if not an archive.
     """
-    # Try magic bytes first
+    # Try magic bytes first (most reliable — extension can be wrong or missing)
     try:
         with open(filepath, "rb") as f:
             header = f.read(8)
 
-        # ZIP: PK (0x50 0x4B)
         if header[:2] == b"PK":
             return "zip"
-        # 7z: 7z signature
         if header[:6] == b"7z\xbc\xaf'\x1c":
             return "7z"
-        # RAR: Rar!
         if header[:4] == b"Rar!":
             return "rar"
     except (OSError, IOError):
@@ -44,9 +40,29 @@ def detect_archive_type(filepath: Path) -> str | None:
         return "zip"
     elif suffix == ".7z":
         return "7z"
-    elif suffix == ".rar":
+    elif suffix in (".rar", ".r00"):
         return "rar"
 
+    return None
+
+
+def detect_archive_type_from_url(url: str) -> str | None:
+    """
+    Detect archive type from a CDN URL (before downloading).
+
+    CDN URLs like https://cdn.nexusmods.com/files/ModName.rar?md5=...
+    have the extension before the query string.
+    """
+    # Strip query string
+    path = url.split("?")[0]
+    suffix = Path(path).suffix.lower()
+
+    if suffix == ".zip":
+        return "zip"
+    elif suffix == ".7z":
+        return "7z"
+    elif suffix in (".rar", ".r00"):
+        return "rar"
     return None
 
 
@@ -66,25 +82,30 @@ def _move_staging_contents(staging_dir: Path, target_dir: Path) -> list[Path]:
 
 def extract_archive(archive_path: Path, target_dir: Path) -> list[Path]:
     """
-    Extract an archive to the target directory.
+    Extract an archive to the target directory, preserving internal structure.
 
     Uses a staging directory to avoid conflicts when the archive contains
     a top-level folder matching the archive filename.
 
-    Returns list of extracted file paths.
+    IMPORTANT: Structure is preserved (not flattened) because BG3 mods often
+    have internal folders like ModName/Data/Public/... that must be kept intact
+    for deploy.py to correctly classify files.
+
+    Returns list of extracted file paths relative to target_dir.
     """
     archive_type = detect_archive_type(archive_path)
     if archive_type is None:
         raise ExtractionError(f"Unknown archive type: {archive_path}")
 
     target_dir.mkdir(parents=True, exist_ok=True)
-    staging_dir = target_dir / f".extracting_{archive_path.stem}"
+
+    # Use a clean temp path to avoid special character issues with system tools
+    staging_dir = Path("/tmp") / f"nexus_extract_{archive_path.stem[:20]}"
 
     try:
-        # Clean up any leftover staging dir from a previous failed run
         if staging_dir.exists():
             shutil.rmtree(staging_dir)
-        staging_dir.mkdir()
+        staging_dir.mkdir(parents=True)
 
         if archive_type == "zip":
             extracted = _extract_zip(archive_path, staging_dir)
@@ -95,33 +116,32 @@ def extract_archive(archive_path: Path, target_dir: Path) -> list[Path]:
         else:
             extracted = []
 
-        # Move extracted files from staging to target
+        # Move extracted files from staging to target, preserving structure
         final_files = _move_staging_contents(staging_dir, target_dir)
         return final_files
 
     except Exception as e:
         raise ExtractionError(f"Failed to extract {archive_path}: {e}")
     finally:
-        # Always clean up staging dir
         if staging_dir.exists():
-            shutil.rmtree(staging_dir)
+            shutil.rmtree(staging_dir, ignore_errors=True)
 
 
 def _extract_zip(archive_path: Path, target_dir: Path) -> list[Path]:
-    """Extract a ZIP archive."""
+    """Extract a ZIP archive, preserving directory structure."""
     extracted = []
     with zipfile.ZipFile(archive_path, "r") as zf:
         for member in zf.namelist():
-            # Skip directories
             if member.endswith("/"):
                 continue
-            zf.extract(member, target_dir)
-            extracted.append(target_dir / member)
+            # ZipFile.extract preserves directory structure
+            dest = zf.extract(member, target_dir)
+            extracted.append(Path(dest))
     return extracted
 
 
 def _extract_7z(archive_path: Path, target_dir: Path) -> list[Path]:
-    """Extract a 7z archive. Falls back to system 7z for unsupported codecs (e.g. BCJ2)."""
+    """Extract a 7z archive. Falls back to system 7z for unsupported codecs."""
     try:
         extracted = []
         with py7zr.SevenZipFile(archive_path, "r") as szf:
@@ -132,19 +152,19 @@ def _extract_7z(archive_path: Path, target_dir: Path) -> list[Path]:
                     extracted.append(path)
         return extracted
     except (py7zr.UnsupportedCompressionMethodError, py7zr.Bad7zFile):
-        # py7zr can't handle this codec - try system 7z
         return _extract_7z_system(archive_path, target_dir)
 
 
 def _extract_7z_system(archive_path: Path, target_dir: Path) -> list[Path]:
-    """Extract a 7z archive using the system 7z command."""
+    """Extract using system 7z command (handles BCJ2 and other complex codecs)."""
     sz_bin = shutil.which("7z") or shutil.which("7zz")
     if not sz_bin:
         raise ExtractionError(
             f"py7zr cannot extract {archive_path.name} (unsupported compression). "
-            "Install p7zip-full (apt install p7zip-full) for broader 7z support."
+            "Install p7zip-full (apt install p7zip-full / dnf install p7zip-plugins)."
         )
 
+    # Use -o with the target_dir path directly (already a clean /tmp path)
     result = subprocess.run(
         [sz_bin, "x", str(archive_path), f"-o{target_dir}", "-y"],
         capture_output=True,
@@ -155,23 +175,55 @@ def _extract_7z_system(archive_path: Path, target_dir: Path) -> list[Path]:
             f"7z extraction failed for {archive_path.name}: {result.stderr.strip()}"
         )
 
-    extracted = []
-    for path in target_dir.rglob("*"):
-        if path.is_file():
-            extracted.append(path)
-    return extracted
+    return [p for p in target_dir.rglob("*") if p.is_file()]
 
 
 def _extract_rar(archive_path: Path, target_dir: Path) -> list[Path]:
-    """Extract a RAR archive."""
-    extracted = []
-    with rarfile.RarFile(archive_path, "r") as rf:
-        rf.extractall(target_dir)
-        for member in rf.namelist():
-            path = target_dir / member
-            if path.is_file():
-                extracted.append(path)
-    return extracted
+    """
+    Extract a RAR archive.
+
+    Tries rarfile (Python) first, then unar (system) as fallback.
+    unar handles RAR5 which rarfile may not support on all systems.
+    """
+    # Try rarfile first
+    try:
+        extracted = []
+        with rarfile.RarFile(archive_path, "r") as rf:
+            rf.extractall(target_dir)
+            for member in rf.namelist():
+                path = target_dir / member
+                if path.is_file():
+                    extracted.append(path)
+        return extracted
+    except Exception:
+        pass
+
+    # Fall back to unar (handles RAR5)
+    unar_bin = shutil.which("unar")
+    if unar_bin:
+        result = subprocess.run(
+            [unar_bin, "-o", str(target_dir), "-f", str(archive_path)],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return [p for p in target_dir.rglob("*") if p.is_file()]
+
+    # Try system unrar
+    unrar_bin = shutil.which("unrar")
+    if unrar_bin:
+        result = subprocess.run(
+            [unrar_bin, "x", "-y", str(archive_path), str(target_dir) + "/"],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return [p for p in target_dir.rglob("*") if p.is_file()]
+
+    raise ExtractionError(
+        f"Cannot extract RAR: {archive_path.name}. "
+        "Install unar (apt install unar / dnf install unar) for RAR5 support."
+    )
 
 
 def is_archive(filepath: Path) -> bool:

--- a/nexus_collection_dl/loadorder.py
+++ b/nexus_collection_dl/loadorder.py
@@ -13,7 +13,13 @@ class LoadOrderError(Exception):
 
 
 class LoadOrderGenerator:
-    """Generates mod and plugin load order from collection metadata."""
+    """Generates mod and plugin load order from collection metadata.
+
+    Now file-aware: a single Nexus mod (mod_id) can contribute multiple files
+    to the collection (e.g. core pak + texture pak + compatibility patch).
+    The load order tracks both mod_id (for phase/dependency ordering) and
+    file_id (for exact file identification and download tracking).
+    """
 
     # Bethesda game domains that support ESP/ESM plugins
     BETHESDA_GAMES = {
@@ -42,15 +48,38 @@ class LoadOrderGenerator:
         """
         Args:
             manifest: Parsed collection manifest
-            mods: List of mod info dicts (from GraphQL, must have mod_id and mod_name)
-            mod_requirements: Map of mod_id -> list of required mod_ids (from GraphQL modRequirements)
+            mods: List of mod file info dicts from GraphQL.
+                  Each entry has: mod_id, file_id, mod_name, filename, optional, etc.
+                  There may be MULTIPLE entries with the same mod_id (multi-file mods).
+            mod_requirements: Map of mod_id -> list of required mod_ids
             game_domain: Game domain name (e.g., 'starfield', 'baldursgate3')
         """
         self.manifest = manifest
-        self.mods = {m["mod_id"]: m for m in mods}
-        self.mod_requirements = mod_requirements
         self.game_domain = game_domain.lower()
         self.is_bethesda = self.game_domain in self.BETHESDA_GAMES
+
+        # Index all files by file_id (primary key)
+        self.files_by_file_id: dict[int, dict[str, Any]] = {
+            m["file_id"]: m for m in mods
+        }
+
+        # Index files by mod_id (one mod may have multiple files)
+        self.files_by_mod_id: dict[int, list[dict[str, Any]]] = defaultdict(list)
+        for m in mods:
+            self.files_by_mod_id[m["mod_id"]].append(m)
+
+        # For dependency resolution we operate at mod_id level
+        # (dependencies are between mods, not individual files)
+        self.mod_requirements = mod_requirements
+
+        # Unique mod_ids in this collection (for topo sort)
+        self.all_mod_ids: set[int] = set(self.files_by_mod_id.keys())
+
+        # Convenience: mod_name by mod_id (use first file's name)
+        self.mod_name_by_id: dict[int, str] = {
+            mid: files[0].get("mod_name", f"Unknown [{mid}]")
+            for mid, files in self.files_by_mod_id.items()
+        }
 
     def generate(self, output_dir: Path) -> list[Path]:
         """
@@ -60,13 +89,15 @@ class LoadOrderGenerator:
         """
         written = []
 
-        # Generate mod load order (all games)
-        mod_order = self._sort_mods()
+        # Sort mods by phase + dependencies (returns ordered list of mod_ids)
+        ordered_mod_ids = self._sort_mods()
+
+        # Write load order (one line per FILE, grouped by mod)
         load_order_path = output_dir / "load-order.txt"
-        self._write_load_order(mod_order, load_order_path)
+        self._write_load_order(ordered_mod_ids, load_order_path)
         written.append(load_order_path)
 
-        # Generate plugins.txt for Bethesda games (from collection metadata)
+        # Generate plugins.txt for Bethesda games
         if self.is_bethesda and self.manifest.plugins:
             plugins_path = output_dir / "plugins.txt"
             self._write_plugins(plugins_path)
@@ -78,84 +109,69 @@ class LoadOrderGenerator:
         """
         Topological sort of mods by phase + dependencies.
 
-        Uses:
-        1. Phase grouping (phase 0 mods before phase 1, etc.)
-        2. modRules from collection (before/after edges)
-        3. modRequirements from GraphQL (author dependencies)
-        """
-        # Collect all mod IDs in this collection
-        all_mod_ids = set(self.mods.keys())
+        Operates at mod_id level (dependencies are between mods, not files).
+        Returns ordered list of mod_ids.
 
-        # Build adjacency list: edges[a] = [b] means a must come before b
+        Uses:
+        1. Phase grouping from manifest (phase 0 before phase 1, etc.)
+        2. modRules from collection manifest (before/after/requires edges)
+        3. modRequirements from GraphQL (author-declared dependencies)
+        """
+        all_mod_ids = self.all_mod_ids
+
+        # Build adjacency list: edges[a] = {b} means mod a must load before mod b
         edges: dict[int, set[int]] = defaultdict(set)
         in_degree: dict[int, int] = {mid: 0 for mid in all_mod_ids}
 
-        # 1. Phase ordering: create edges from lower phase to higher phase mods
-        phase_groups: dict[int, list[int]] = defaultdict(list)
-        for mod_id in all_mod_ids:
-            phase = self.manifest.mod_phases.get(mod_id, 0)
-            phase_groups[phase].append(mod_id)
+        def _add_edge(before_id: int, after_id: int) -> None:
+            """Add a before→after ordering edge, avoiding duplicates."""
+            if before_id == after_id:
+                return
+            if before_id not in all_mod_ids or after_id not in all_mod_ids:
+                return
+            if after_id not in edges[before_id]:
+                edges[before_id].add(after_id)
+                in_degree[after_id] = in_degree.get(after_id, 0) + 1
 
-        sorted_phases = sorted(phase_groups.keys())
-        for i in range(len(sorted_phases) - 1):
-            current_phase = sorted_phases[i]
-            next_phase = sorted_phases[i + 1]
-            # Any mod in current phase must come before any mod in next phase
-            # We only add edge from last mod in current to first in next (lightweight)
-            # Actually, for correctness with topo sort, we need proper phase barriers.
-            # Use a simpler approach: assign phase weight and sort by it, then topo within.
-            pass  # Handled below via weighted sort
-
-        # 2. modRules from collection manifest
-        # Rules use logicalFileName to identify mods, not modId directly
+        # 1. modRules from collection manifest
+        # Rules use logicalFileName to identify files, which maps to mod_ids
         lf_to_id = self.manifest.logical_name_to_mod_id
         for rule in self.manifest.mod_rules:
             rule_type = rule.get("type", "")
-            # Rules have "source" and "reference" (not "target")
             source_lf = rule.get("source", {}).get("logicalFileName", "")
             ref_lf = rule.get("reference", {}).get("logicalFileName", "")
 
-            source_id = lf_to_id.get(source_lf)
-            ref_id = lf_to_id.get(ref_lf)
+            source_mod_id = lf_to_id.get(source_lf)
+            ref_mod_id = lf_to_id.get(ref_lf)
 
-            if source_id is None or ref_id is None:
-                continue
-            if source_id not in all_mod_ids or ref_id not in all_mod_ids:
+            if source_mod_id is None or ref_mod_id is None:
                 continue
 
             if rule_type == "before":
-                # source should load before reference
-                edges[source_id].add(ref_id)
-                in_degree[ref_id] = in_degree.get(ref_id, 0) + 1
+                # source loads before reference
+                _add_edge(source_mod_id, ref_mod_id)
             elif rule_type == "after":
-                # source should load after reference -> reference before source
-                edges[ref_id].add(source_id)
-                in_degree[source_id] = in_degree.get(source_id, 0) + 1
+                # source loads after reference
+                _add_edge(ref_mod_id, source_mod_id)
             elif rule_type == "requires":
-                # source requires reference -> reference before source
-                edges[ref_id].add(source_id)
-                in_degree[source_id] = in_degree.get(source_id, 0) + 1
+                # source requires reference → reference loads first
+                _add_edge(ref_mod_id, source_mod_id)
 
-        # 3. modRequirements from GraphQL
+        # 2. modRequirements from GraphQL (author-declared dependencies)
         for mod_id, req_ids in self.mod_requirements.items():
-            if mod_id not in all_mod_ids:
-                continue
             for req_id in req_ids:
-                if req_id not in all_mod_ids:
-                    continue
-                # Required mod should come before dependent
-                if req_id not in edges or mod_id not in edges[req_id]:
-                    edges[req_id].add(mod_id)
-                    in_degree[mod_id] = in_degree.get(mod_id, 0) + 1
+                # Required mod loads before dependent mod
+                _add_edge(req_id, mod_id)
 
-        # Kahn's algorithm with phase-aware priority
-        # Mods with lower phase get priority, then by name for stability
+        # 3. Kahn's algorithm with phase-aware priority queue
+        # Lower phase = higher priority. Within same phase, sort by name for stability.
         import heapq
-        queue: list[tuple[int, str, int]] = []  # (phase, name, mod_id)
+        queue: list[tuple[int, str, int]] = []  # (phase, name_lower, mod_id)
+
         for mod_id in all_mod_ids:
             if in_degree.get(mod_id, 0) == 0:
                 phase = self.manifest.mod_phases.get(mod_id, 0)
-                name = self.mods.get(mod_id, {}).get("mod_name", "")
+                name = self.mod_name_by_id.get(mod_id, "")
                 heapq.heappush(queue, (phase, name.lower(), mod_id))
 
         result: list[int] = []
@@ -170,41 +186,60 @@ class LoadOrderGenerator:
                 in_degree[neighbor] -= 1
                 if in_degree[neighbor] == 0:
                     phase = self.manifest.mod_phases.get(neighbor, 0)
-                    name = self.mods.get(neighbor, {}).get("mod_name", "")
+                    name = self.mod_name_by_id.get(neighbor, "")
                     heapq.heappush(queue, (phase, name.lower(), neighbor))
 
         if visited < len(all_mod_ids):
-            # Cycle detected — add remaining mods in phase/name order
+            # Cycle detected — append remaining mods in phase/name order
             remaining = all_mod_ids - set(result)
             for mod_id in sorted(
                 remaining,
                 key=lambda m: (
                     self.manifest.mod_phases.get(m, 0),
-                    self.mods.get(m, {}).get("mod_name", "").lower(),
+                    self.mod_name_by_id.get(m, "").lower(),
                 ),
             ):
                 result.append(mod_id)
 
         return result
 
-    def _write_load_order(self, mod_order: list[int], path: Path) -> None:
-        """Write mod load order file."""
+    def _write_load_order(self, ordered_mod_ids: list[int], path: Path) -> None:
+        """
+        Write mod load order file.
+
+        For multi-file mods, all files from that mod appear together in order,
+        since they share the same phase and dependencies.
+
+        Format:
+            N. [mod_id:file_id] mod_name - file_name
+        """
+        # Count total files for header
+        total_files = sum(
+            len(self.files_by_mod_id.get(mid, []))
+            for mid in ordered_mod_ids
+        )
+
         lines = [
             "# Mod Load Order",
-            f"# Generated by nexus-collection-dl",
+            "# Generated by nexus-collection-dl",
             f"# Game: {self.game_domain}",
-            f"# Total mods: {len(mod_order)}",
+            f"# Total mods: {len(ordered_mod_ids)}",
+            f"# Total files: {total_files}",
             "#",
             "# Mods are listed in load order (first = loaded first).",
+            "# Multi-file mods list each file on a separate line.",
+            "# Format: N. [mod_id:file_id] Mod Name - File Name",
             "# Phase groups are separated by blank lines.",
             "",
         ]
 
         current_phase = None
-        for i, mod_id in enumerate(mod_order, 1):
+        entry_num = 0
+
+        for mod_id in ordered_mod_ids:
             phase = self.manifest.mod_phases.get(mod_id, 0)
-            mod = self.mods.get(mod_id, {})
-            name = mod.get("mod_name", f"Unknown (ID: {mod_id})")
+            mod_name = self.mod_name_by_id.get(mod_id, f"Unknown [{mod_id}]")
+            files = self.files_by_mod_id.get(mod_id, [])
 
             if phase != current_phase:
                 if current_phase is not None:
@@ -212,7 +247,27 @@ class LoadOrderGenerator:
                 lines.append(f"# --- Phase {phase} ---")
                 current_phase = phase
 
-            lines.append(f"{i:4d}. [{mod_id}] {name}")
+            if len(files) == 1:
+                # Single file mod — simple format
+                entry_num += 1
+                f = files[0]
+                file_id = f.get("file_id", 0)
+                file_name = f.get("filename", "")
+                opt = " [optional]" if f.get("optional") else ""
+                lines.append(
+                    f"{entry_num:4d}. [{mod_id}:{file_id}] {mod_name}{opt}"
+                )
+            else:
+                # Multi-file mod — show mod header then each file
+                lines.append(f"       # {mod_name} ({len(files)} files)")
+                for f in files:
+                    entry_num += 1
+                    file_id = f.get("file_id", 0)
+                    file_name = f.get("filename", "")
+                    opt = " [optional]" if f.get("optional") else ""
+                    lines.append(
+                        f"{entry_num:4d}. [{mod_id}:{file_id}] {mod_name} - {file_name}{opt}"
+                    )
 
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("\n".join(lines) + "\n")
@@ -221,7 +276,7 @@ class LoadOrderGenerator:
         """Write plugins.txt for Bethesda games from collection metadata."""
         lines = [
             "# Plugin Load Order (from collection metadata)",
-            f"# Generated by nexus-collection-dl",
+            "# Generated by nexus-collection-dl",
             f"# Game: {self.game_domain}",
             "#",
             "# This is the collection author's intended plugin order.",
@@ -239,3 +294,22 @@ class LoadOrderGenerator:
 
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("\n".join(lines) + "\n")
+
+    def get_ordered_files(self) -> list[dict[str, Any]]:
+        """
+        Return all mod files in load order as a flat list.
+
+        Useful for generating modsettings.lsx or other game-specific
+        configuration files that need the exact ordered file list.
+
+        Returns list of file dicts, each with:
+            mod_id, file_id, mod_name, filename, optional, phase
+        """
+        ordered_mod_ids = self._sort_mods()
+        result = []
+        for mod_id in ordered_mod_ids:
+            files = self.files_by_mod_id.get(mod_id, [])
+            phase = self.manifest.mod_phases.get(mod_id, 0)
+            for f in files:
+                result.append({**f, "phase": phase})
+        return result

--- a/nexus_collection_dl/service.py
+++ b/nexus_collection_dl/service.py
@@ -251,14 +251,14 @@ class ModManagerService:
                     status="not_installed",
                 ))
 
-            for mod_id in to_remove:
-                installed = state.get_mod(mod_id)
+            for file_id in to_remove:
+                installed = state.get_file(file_id)
                 if installed:
                     mod_statuses.append(ModStatus(
-                        mod_id=mod_id,
+                        mod_id=installed.mod_id,
                         name=installed.name,
                         version=installed.version,
-                        file_id=installed.file_id,
+                        file_id=file_id,
                         optional=installed.optional,
                         manual=installed.manual,
                         phase=installed.phase,
@@ -267,13 +267,13 @@ class ModManagerService:
 
         except (NexusAPIError, CollectionParseError):
             # Offline/no API - just show installed mods
-            for mod_id, ms in state.mods.items():
+            for file_id, ms in state.mods.items():
                 status = "pending_download" if ms.download_status == "pending_download" else "installed"
                 mod_statuses.append(ModStatus(
-                    mod_id=mod_id,
+                    mod_id=ms.mod_id,
                     name=ms.name,
                     version=ms.version,
-                    file_id=ms.file_id,
+                    file_id=file_id,
                     optional=ms.optional,
                     manual=ms.manual,
                     phase=ms.phase,
@@ -281,14 +281,14 @@ class ModManagerService:
                 ))
 
         # Add manual mods that aren't already in the list
-        listed_ids = {m.mod_id for m in mod_statuses}
-        for mod_id, ms in state.mods.items():
-            if mod_id not in listed_ids and ms.manual:
+        listed_file_ids = {m.file_id for m in mod_statuses}
+        for file_id, ms in state.mods.items():
+            if file_id not in listed_file_ids and ms.manual:
                 mod_statuses.append(ModStatus(
-                    mod_id=mod_id,
+                    mod_id=ms.mod_id,
                     name=ms.name,
                     version=ms.version,
-                    file_id=ms.file_id,
+                    file_id=file_id,
                     optional=ms.optional,
                     manual=True,
                     phase=ms.phase,
@@ -369,9 +369,9 @@ class ModManagerService:
             game_domain = collection_data["game_domain"]
             for mod in mods:
                 mod_id = mod["mod_id"]
-                # Don't regress already-downloaded mods
-                existing = state.get_mod(mod_id)
-                if existing and existing.download_status == "downloaded" and existing.file_id == mod["file_id"]:
+                # Don't regress already-downloaded files (check by file_id)
+                existing = state.get_file(mod["file_id"])
+                if existing and existing.download_status == "downloaded":
                     continue
                 browser_url = f"https://www.nexusmods.com/{game_domain}/mods/{mod_id}?tab=files&file_id={mod['file_id']}"
                 size_bytes = int(mod.get("size_bytes", 0) or mod.get("size", 0) or 0)
@@ -567,7 +567,7 @@ class ModManagerService:
                 game_domain = collection_data["game_domain"]
                 for mod in mods_to_download:
                     mod_id = mod["mod_id"]
-                    existing = state.get_mod(mod_id)
+                    existing = state.get_file(mod["file_id"])
                     if existing and existing.download_status == "downloaded":
                         continue
                     browser_url = f"https://www.nexusmods.com/{game_domain}/mods/{mod_id}?tab=files&file_id={mod['file_id']}"
@@ -1157,26 +1157,26 @@ class ModManagerService:
 
         manifest = CollectionManifest.from_dict(state.manifest_data)
 
-        # Inject phase 999 for manual mods
-        for mod_id, ms in state.mods.items():
+        # Inject phase 999 for manual mods (keyed by mod_id in manifest)
+        for file_id, ms in state.mods.items():
             if ms.manual:
-                manifest.mod_phases[mod_id] = 999
+                manifest.mod_phases[ms.mod_id] = 999
 
         mod_requirements: dict[int, list[int]] = {}
-        for mod_id, mod_state in state.mods.items():
+        for file_id, mod_state in state.mods.items():
             if mod_state.requirements:
-                mod_requirements[mod_id] = mod_state.requirements
+                mod_requirements[mod_state.mod_id] = mod_state.requirements
 
         mods_list = [
             {
-                "mod_id": mod_id,
+                "mod_id": ms.mod_id,
                 "mod_name": ms.name,
-                "file_id": ms.file_id,
+                "file_id": file_id,
                 "version": ms.version,
                 "filename": ms.filename,
                 "optional": ms.optional,
             }
-            for mod_id, ms in state.mods.items()
+            for file_id, ms in state.mods.items()
         ]
 
         generator = LoadOrderGenerator(

--- a/nexus_collection_dl/state.py
+++ b/nexus_collection_dl/state.py
@@ -10,18 +10,21 @@ STATE_FILENAME = ".nexus-state.json"
 
 class StateError(Exception):
     """Raised when state file operations fail."""
-
     pass
 
 
 class ModState:
-    """Represents the installed state of a mod."""
+    """Represents the installed state of a single mod FILE.
+
+    NOTE: A single Nexus mod (mod_id) can have multiple files in a collection.
+    State is keyed by file_id, not mod_id, to support this correctly.
+    """
 
     def __init__(
         self,
+        file_id: int,
         mod_id: int,
         name: str,
-        file_id: int,
         version: str,
         filename: str,
         installed_at: str | None = None,
@@ -33,9 +36,9 @@ class ModState:
         download_status: str = "downloaded",
         browser_url: str = "",
     ):
+        self.file_id = file_id
         self.mod_id = mod_id
         self.name = name
-        self.file_id = file_id
         self.version = version
         self.filename = filename
         self.installed_at = installed_at or datetime.now(timezone.utc).isoformat()
@@ -49,8 +52,8 @@ class ModState:
 
     def to_dict(self) -> dict[str, Any]:
         return {
+            "mod_id": self.mod_id,
             "name": self.name,
-            "file_id": self.file_id,
             "version": self.version,
             "filename": self.filename,
             "installed_at": self.installed_at,
@@ -64,11 +67,11 @@ class ModState:
         }
 
     @classmethod
-    def from_dict(cls, mod_id: int, data: dict[str, Any]) -> "ModState":
+    def from_dict(cls, file_id: int, data: dict[str, Any]) -> "ModState":
         return cls(
-            mod_id=mod_id,
+            file_id=file_id,
+            mod_id=data.get("mod_id", 0),
             name=data.get("name", ""),
-            file_id=data.get("file_id", 0),
             version=data.get("version", ""),
             filename=data.get("filename", ""),
             installed_at=data.get("installed_at"),
@@ -94,6 +97,8 @@ class CollectionState:
         self.game_domain: str = ""
         self.mod_rules: list = []
         self.manifest_data: dict | None = None
+        # Key: file_id (int) -> ModState
+        # Using file_id as key ensures all files from multi-file mods are tracked.
         self.mods: dict[int, ModState] = {}
         self.game_dir: str = ""
         self.proton_prefix: str = ""
@@ -129,9 +134,9 @@ class CollectionState:
         self.track_sync_enabled = data.get("track_sync_enabled", False)
 
         self.mods = {}
-        for mod_id_str, mod_data in data.get("mods", {}).items():
-            mod_id = int(mod_id_str)
-            self.mods[mod_id] = ModState.from_dict(mod_id, mod_data)
+        for file_id_str, mod_data in data.get("mods", {}).items():
+            file_id = int(file_id_str)
+            self.mods[file_id] = ModState.from_dict(file_id, mod_data)
 
     def save(self) -> None:
         """Save state to file."""
@@ -144,7 +149,8 @@ class CollectionState:
             "game_domain": self.game_domain,
             "mod_rules": self.mod_rules,
             "manifest_data": self.manifest_data,
-            "mods": {str(mod_id): mod.to_dict() for mod_id, mod in self.mods.items()},
+            # Key by file_id so each file from a multi-file mod is tracked
+            "mods": {str(file_id): mod.to_dict() for file_id, mod in self.mods.items()},
             "game_dir": self.game_dir,
             "proton_prefix": self.proton_prefix,
             "deployed_files": self.deployed_files,
@@ -165,12 +171,12 @@ class CollectionState:
         self.game_domain = game_domain
 
     def add_mod(self, mod_info: dict[str, Any]) -> None:
-        """Add or update a mod in the state."""
-        mod_id = mod_info["mod_id"]
-        self.mods[mod_id] = ModState(
-            mod_id=mod_id,
+        """Add or update a mod file in the state (keyed by file_id)."""
+        file_id = mod_info["file_id"]
+        self.mods[file_id] = ModState(
+            file_id=file_id,
+            mod_id=mod_info["mod_id"],
             name=mod_info["mod_name"],
-            file_id=mod_info["file_id"],
             version=mod_info["version"] or "",
             filename=mod_info["filename"],
             optional=mod_info.get("optional", False),
@@ -185,45 +191,78 @@ class CollectionState:
         """Return mods with pending_download status."""
         return [ms for ms in self.mods.values() if ms.download_status == "pending_download"]
 
+    def remove_mod_file(self, file_id: int) -> None:
+        """Remove a specific file from the state."""
+        self.mods.pop(file_id, None)
+
     def remove_mod(self, mod_id: int) -> None:
-        """Remove a mod from the state."""
-        self.mods.pop(mod_id, None)
+        """Remove ALL files for a given mod_id from the state."""
+        to_remove = [fid for fid, ms in self.mods.items() if ms.mod_id == mod_id]
+        for fid in to_remove:
+            del self.mods[fid]
 
     def get_mod(self, mod_id: int) -> ModState | None:
-        """Get mod state by ID."""
-        return self.mods.get(mod_id)
+        """Get first mod state by mod_id (for backwards compat)."""
+        for ms in self.mods.values():
+            if ms.mod_id == mod_id:
+                return ms
+        return None
+
+    def get_file(self, file_id: int) -> ModState | None:
+        """Get mod state by file_id."""
+        return self.mods.get(file_id)
+
+    def get_downloaded_file_ids(self) -> set[int]:
+        """Return set of all downloaded file_ids."""
+        return {fid for fid, ms in self.mods.items()
+                if ms.download_status == "downloaded"}
+
+    def get_downloaded_mod_ids(self) -> set[int]:
+        """Return set of mod_ids that have at least one downloaded file."""
+        return {ms.mod_id for ms in self.mods.values()
+                if ms.download_status == "downloaded"}
 
     def compare_with_collection(
         self, collection_mods: list[dict[str, Any]]
     ) -> tuple[list[dict], list[dict], list[dict], list[int]]:
         """
-        Compare installed mods with collection.
+        Compare installed mod FILES with collection.
+
+        Since state is now keyed by file_id, we compare file_ids directly.
+        A mod with a new file_id = update available.
 
         Returns:
-            - to_install: mods in collection but not installed
-            - to_update: mods with different file_id (new version)
-            - up_to_date: mods that match
-            - to_remove: mod IDs installed but not in collection
+            - to_install: files in collection but not installed
+            - to_update: files with matching mod_id but different file_id
+            - up_to_date: files that match exactly
+            - to_remove: file_ids installed but not in collection (excluding manual)
         """
+        collection_file_ids = {m["file_id"] for m in collection_mods}
         collection_mod_ids = {m["mod_id"] for m in collection_mods}
-        installed_mod_ids = set(self.mods.keys())
+        installed_file_ids = set(self.mods.keys())
 
         to_install = []
         to_update = []
         up_to_date = []
 
-        for mod in collection_mods:
-            mod_id = mod["mod_id"]
-            installed = self.mods.get(mod_id)
+        # Build mod_id -> installed file_ids mapping
+        mod_id_to_installed_files: dict[int, list[int]] = {}
+        for fid, ms in self.mods.items():
+            mod_id_to_installed_files.setdefault(ms.mod_id, []).append(fid)
 
-            if installed is None:
-                to_install.append(mod)
-            elif installed.file_id != mod["file_id"]:
+        for mod in collection_mods:
+            file_id = mod["file_id"]
+            mod_id = mod["mod_id"]
+
+            if file_id in installed_file_ids:
+                up_to_date.append(mod)
+            elif mod_id in mod_id_to_installed_files:
+                # Same mod but different file — update available
                 to_update.append(mod)
             else:
-                up_to_date.append(mod)
+                to_install.append(mod)
 
-        manual_mod_ids = {mid for mid, ms in self.mods.items() if ms.manual}
-        to_remove = list(installed_mod_ids - collection_mod_ids - manual_mod_ids)
+        manual_file_ids = {fid for fid, ms in self.mods.items() if ms.manual}
+        to_remove = list(installed_file_ids - collection_file_ids - manual_file_ids)
 
         return to_install, to_update, up_to_date, to_remove

--- a/nexus_collection_dl/steam.py
+++ b/nexus_collection_dl/steam.py
@@ -11,6 +11,7 @@ STEAM_APP_IDS = {
     "fallout4": "377160",
     "falloutnewvegas": "22380",
     "fallout3": "22300",
+    "baldursgate3": "1086940",
     "oblivion": "22330",
     "morrowind": "22320",
     "enderal": "933480",


### PR DESCRIPTION
Title: Fix multi-file mod support, add BG3 deployment, fix extraction structure
Summary
This PR fixes a critical bug where collections containing multiple files from the same Nexus mod (same mod_id, different file_ids) would silently drop all but one file per mod. It also adds proper Baldur's Gate 3 deployment support and fixes archive extraction to preserve folder structure.

Bug: Multi-file mods silently dropped (api.py, state.py, service.py)
The get_collection_mods() function deduplicated results by mod_id, keeping only the last file for any mod that appeared multiple times in a collection. This is incorrect — a single Nexus mod can contribute multiple distinct files to a collection.
Real-world impact on the Difficulty, Immersion, Quality BG3 collection (1004 files, 855 unique mods):

ABSolutely (mod 18726) has 5 files — only 1 was downloaded
Goon's Dividers (mod 9784) has 122 files — only 1 was downloaded
Ripped Physique (mod 13223) has 3 files — only 1 was downloaded
Approximately 150 files were silently dropped across the collection

Fix: Remove mod_id deduplication from get_collection_mods(). Only deduplicate on file_id (which should be globally unique). Update CollectionState to key by file_id instead of mod_id, and update all service.py iteration accordingly.

Feature: Baldur's Gate 3 deployment support (deploy.py, steam.py)
BG3 uses a different mod structure than Bethesda games:

.pak files go in Data/ (symlinked from collection staging folder)
Native mod DLLs go in bin/NativeMods/
Loose files with a Data/ prefix deploy to game Data/
Virtual texture files (.gts/.gtp) deploy to Data/ structure
Mac __MACOSX artifacts are skipped
JSON/URL/LNK files are skipped

Also adds BG3 app ID 1086940 to steam.py.

Fix: Archive extraction preserves folder structure (extractor.py)
The extractor was using a staging directory path that could contain special characters from mod names, causing system tool failures. Extraction now uses a clean /tmp path.
More importantly, extracted files are now moved to the target preserving their internal folder structure. This is critical for mods that ship loose files with paths like ModName/Data/Public/... — flattening these broke deployment classification entirely.
RAR extraction now tries rarfile → unar → unrar in order, with unar as the preferred fallback since it handles RAR5 which rarfile often cannot.

Testing
Tested against the Difficulty, Immersion, Quality BG3 collection (pns4qv), revision 144, which contains 1004 files across 855 mods. Previously only ~850 files were downloaded due to the deduplication bug. After this fix all 1004 files download correctly.